### PR TITLE
Prevent non-admins from creating shipments

### DIFF
--- a/src/apolloServer.ts
+++ b/src/apolloServer.ts
@@ -1,15 +1,23 @@
-import { ApolloServer, AuthenticationError } from 'apollo-server-express'
+import {
+  ApolloServer,
+  ApolloServerExpressConfig,
+  AuthenticationError,
+} from 'apollo-server-express'
 import depthLimit from 'graphql-depth-limit'
 
 import resolvers from './resolvers'
 import typeDefs from './typeDefs'
-import { authenticateRequest } from './authenticateRequest'
+import { Auth, authenticateRequest } from './authenticateRequest'
 
-const apolloServer = new ApolloServer({
+export type Context = {
+  auth: Auth
+}
+
+export const serverConfig: ApolloServerExpressConfig = {
   typeDefs,
   resolvers,
   validationRules: [depthLimit(7)],
-  async context({ req }) {
+  async context({ req }): Promise<Context> {
     const auth = await authenticateRequest(req)
 
     if (auth.userAccount == null) {
@@ -20,6 +28,8 @@ const apolloServer = new ApolloServer({
 
     return { auth }
   },
-})
+}
+
+const apolloServer = new ApolloServer(serverConfig)
 
 export default apolloServer

--- a/src/resolvers/shipment/index.ts
+++ b/src/resolvers/shipment/index.ts
@@ -1,4 +1,9 @@
-import { UserInputError, ApolloError } from 'apollo-server'
+import {
+  UserInputError,
+  ApolloError,
+  AuthenticationError,
+  ForbiddenError,
+} from 'apollo-server'
 
 import {
   QueryResolvers,
@@ -9,6 +14,7 @@ import {
 import { sequelize } from '../../sequelize'
 import Shipment from '../../models/shipment'
 import Group from '../../models/group'
+import { Context } from '../../apolloServer'
 
 const shipmentRepository = sequelize.getRepository(Shipment)
 const groupRepository = sequelize.getRepository(Group)
@@ -22,8 +28,12 @@ const listShipments: QueryResolvers['listShipments'] = async () => {
 const addShipment: MutationResolvers['addShipment'] = async (
   _parent,
   { input },
-  _context,
+  context: Context,
 ) => {
+  if (!context.auth.isAdmin) {
+    throw new ForbiddenError('addShipment forbidden to non-admin users')
+  }
+
   if (
     !input.shippingRoute ||
     !input.labelYear ||

--- a/src/testServer.ts
+++ b/src/testServer.ts
@@ -1,8 +1,27 @@
+import { ApolloServer, ApolloServerExpressConfig } from 'apollo-server-express'
 import { createTestClient, ApolloServerTestClient } from 'apollo-server-testing'
-import { ApolloServer } from 'apollo-server'
-import resolvers from './resolvers'
-import typeDefs from './typeDefs'
+import { merge } from 'lodash'
+import { serverConfig } from './apolloServer'
+import { fakeUserAuth, fakeAdminAuth } from './authenticateRequest'
 
-export default function makeTestServer(): ApolloServerTestClient {
-  return createTestClient(new ApolloServer({ typeDefs, resolvers }))
+export const makeTestServer = (
+  overrides: Partial<ApolloServerExpressConfig> = {},
+): ApolloServerTestClient => {
+  const defaultOverrides = {
+    context: () => ({
+      auth: fakeUserAuth,
+    }),
+  }
+
+  return createTestClient(
+    new ApolloServer(merge(serverConfig, defaultOverrides, overrides)),
+  )
 }
+
+export const makeAdminTestServer = (
+  overrides: Partial<ApolloServerExpressConfig> = {},
+) =>
+  makeTestServer({
+    context: () => ({ auth: fakeAdminAuth }),
+    ...overrides,
+  })

--- a/src/tests/groups_api.test.ts
+++ b/src/tests/groups_api.test.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 import { ApolloServerTestClient } from 'apollo-server-testing'
 
-import makeTestServer from '../testServer'
+import { makeTestServer } from '../testServer'
 import { sequelize } from '../sequelize'
 import Group from '../models/group'
 import { createGroup } from './helpers'


### PR DESCRIPTION
The behavior change is pretty small here: a single auth check on the only API endpoints that's restricted to the admin so far.

The testing side of it is a bit more involved though. I couldn't find a way to fake auth or the calling user's creds that didn't involve instantiating a completely different apollo server instance per-user. I tried to make that as painless as possible to work with, but it's still a little weird. Very much open to other approaches if someone has a different idea.