### PR TITLE
Default new group's captain to creator

### DIFF
--- a/db/migrations/20210308070729-add-captain-to-group.js
+++ b/db/migrations/20210308070729-add-captain-to-group.js
@@ -2,9 +2,6 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.bulkDelete('Shipments', {})
-    await queryInterface.bulkDelete('Groups', {})
-
     await queryInterface.addColumn('Groups', 'captainId', {
       allowNull: false,
       type: Sequelize.INTEGER,

--- a/db/migrations/20210308070729-add-captain-to-group.js
+++ b/db/migrations/20210308070729-add-captain-to-group.js
@@ -1,0 +1,18 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Shipments', {})
+    await queryInterface.bulkDelete('Groups', {})
+
+    await queryInterface.addColumn('Groups', 'captainId', {
+      allowNull: false,
+      type: Sequelize.INTEGER,
+      references: { model: 'UserAccounts', key: 'id' },
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Groups', 'captainId')
+  },
+}

--- a/db/seeders/20210302050835-demo-groups.js
+++ b/db/seeders/20210302050835-demo-groups.js
@@ -1,7 +1,24 @@
 'use strict'
 
+const { captureRejectionSymbol } = require('ws')
+
 module.exports = {
   up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('UserAccounts', [
+      {
+        auth0Id: 'seeded-account-id',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ])
+
+    const [{ id: captainId }] = await queryInterface.sequelize.query(
+      'SELECT id FROM "UserAccounts" LIMIT 1',
+      {
+        type: queryInterface.sequelize.QueryTypes.SELECT,
+      },
+    )
+
     await queryInterface.bulkInsert(
       'Groups',
       [
@@ -17,6 +34,7 @@ module.exports = {
           primaryContact: JSON.stringify({
             name: 'Myriam McLaughlin',
           }),
+          captainId,
         },
         {
           name: 'Brighton',
@@ -30,6 +48,7 @@ module.exports = {
           primaryContact: JSON.stringify({
             name: 'Meaghan Crist',
           }),
+          captainId,
         },
         {
           name: 'Calais',
@@ -43,6 +62,7 @@ module.exports = {
           primaryContact: JSON.stringify({
             name: 'Jacinthe Donnelly',
           }),
+          captainId,
         },
       ],
       {},

--- a/frontend/src/types/api-types.ts
+++ b/frontend/src/types/api-types.ts
@@ -141,3 +141,9 @@ export enum GroupType {
   ReceivingGroup = 'RECEIVING_GROUP',
   SendingGroup = 'SENDING_GROUP',
 }
+
+export type UserProfile = {
+  __typename?: 'UserProfile'
+  id: Scalars['Int']
+  isAdmin: Scalars['Boolean']
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -106,3 +106,8 @@ enum GroupType {
   RECEIVING_GROUP
   SENDING_GROUP
 }
+
+type UserProfile {
+  id: Int!
+  isAdmin: Boolean!
+}

--- a/src/apolloServer.ts
+++ b/src/apolloServer.ts
@@ -7,17 +7,25 @@ import depthLimit from 'graphql-depth-limit'
 
 import resolvers from './resolvers'
 import typeDefs from './typeDefs'
-import { Auth, authenticateRequest } from './authenticateRequest'
+import {
+  Auth,
+  AuthenticatedAuth,
+  authenticateRequest,
+} from './authenticateRequest'
 
 export type Context = {
   auth: Auth
+}
+
+export type AuthenticatedContext = {
+  auth: AuthenticatedAuth
 }
 
 export const serverConfig: ApolloServerExpressConfig = {
   typeDefs,
   resolvers,
   validationRules: [depthLimit(7)],
-  async context({ req }): Promise<Context> {
+  async context({ req }): Promise<AuthenticatedContext> {
     const auth = await authenticateRequest(req)
 
     if (auth.userAccount == null) {
@@ -26,7 +34,7 @@ export const serverConfig: ApolloServerExpressConfig = {
       )
     }
 
-    return { auth }
+    return { auth: auth as AuthenticatedAuth }
   },
 }
 

--- a/src/authenticateRequest.ts
+++ b/src/authenticateRequest.ts
@@ -102,6 +102,12 @@ export type Auth = {
   isAdmin: boolean
 }
 
+export type AuthenticatedAuth = {
+  claims: AuthClaims
+  userAccount: UserAccount
+  isAdmin: boolean
+}
+
 const fakeAccount = userAccountRepository.build({ auth0Id: '' })
 const fakeClaims = {
   roles: [],

--- a/src/findOrCreateProfile.ts
+++ b/src/findOrCreateProfile.ts
@@ -1,17 +1,29 @@
 import { Request, Response } from 'express'
 
+import { UserProfile } from './server-internal-types'
 import UserAccount from './models/user_account'
 import { authenticateRequest } from './authenticateRequest'
 import { sequelize } from './sequelize'
 
 const userAccountRepository = sequelize.getRepository(UserAccount)
 
+const sendProfile = (
+  response: Response,
+  userAccount: UserAccount,
+  isAdmin = false,
+) => {
+  const profile: UserProfile = { id: userAccount.id, isAdmin }
+
+  response.json(profile).end()
+}
+
 const findOrCreateProfile = async (request: Request, response: Response) => {
   const auth = await authenticateRequest(request)
 
   if (auth.userAccount != null) {
     console.info('found account for profile', auth.claims.sub)
-    response.status(200).end()
+
+    sendProfile(response, auth.userAccount, auth.isAdmin)
     return
   }
 
@@ -23,7 +35,7 @@ const findOrCreateProfile = async (request: Request, response: Response) => {
 
   console.info('created user account', userAccount.id)
 
-  response.status(200).end()
+  sendProfile(response, userAccount)
 }
 
 export default findOrCreateProfile

--- a/src/models/group.ts
+++ b/src/models/group.ts
@@ -6,8 +6,11 @@ import {
   CreatedAt,
   UpdatedAt,
   DataType,
+  ForeignKey,
+  BelongsTo,
 } from 'sequelize-typescript'
 import { GroupType, Location, ContactInfo } from '../server-internal-types'
+import UserAccount from './user_account'
 
 export interface GroupAttributes {
   id: number
@@ -16,6 +19,7 @@ export interface GroupAttributes {
   primaryLocation: Location
   primaryContact: ContactInfo
   website?: string | null
+  captainId: number
 }
 
 export interface GroupCreationAttributes
@@ -44,6 +48,13 @@ export default class Group extends Model<
 
   @Column
   public website?: string
+
+  @ForeignKey(() => UserAccount)
+  @Column
+  public captainId!: number
+
+  @BelongsTo(() => UserAccount, 'captainId')
+  public captain!: UserAccount
 
   @CreatedAt
   @Column

--- a/src/resolvers/group/index.ts
+++ b/src/resolvers/group/index.ts
@@ -7,6 +7,8 @@ import {
 } from '../../server-internal-types'
 import { sequelize } from '../../sequelize'
 import Group from '../../models/group'
+import { AuthenticatedContext, Context } from '../../apolloServer'
+import UserAccount from '../../models/user_account'
 
 const groupRepository = sequelize.getRepository(Group)
 
@@ -27,7 +29,7 @@ const group: QueryResolvers['group'] = async (_, { id }) => {
 const addGroup: MutationResolvers['addGroup'] = async (
   _parent,
   { input },
-  _context,
+  context: AuthenticatedContext,
 ) => {
   if (
     !input.name ||
@@ -48,6 +50,7 @@ const addGroup: MutationResolvers['addGroup'] = async (
     primaryLocation: input.primaryLocation,
     primaryContact: input.primaryContact,
     website: input.website,
+    captainId: context.auth.userAccount.id,
   })
 }
 

--- a/src/server-internal-types.ts
+++ b/src/server-internal-types.ts
@@ -145,6 +145,12 @@ export enum GroupType {
   SendingGroup = 'SENDING_GROUP',
 }
 
+export type UserProfile = {
+  __typename?: 'UserProfile'
+  id: Scalars['Int']
+  isAdmin: Scalars['Boolean']
+}
+
 export type WithIndex<TObject> = TObject & Record<string, any>
 export type ResolversObject<TObject> = WithIndex<TObject>
 
@@ -280,6 +286,7 @@ export type ResolversTypes = ResolversObject<{
   ShipmentStatus: ShipmentStatus
   Shipment: ResolverTypeWrapper<Shipment>
   GroupType: GroupType
+  UserProfile: ResolverTypeWrapper<UserProfile>
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>
 }>
 
@@ -298,6 +305,7 @@ export type ResolversParentTypes = ResolversObject<{
   Mutation: {}
   ShipmentInput: ShipmentInput
   Shipment: Shipment
+  UserProfile: UserProfile
   Boolean: Scalars['Boolean']
 }>
 
@@ -423,6 +431,15 @@ export type ShipmentResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
 
+export type UserProfileResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UserProfile'] = ResolversParentTypes['UserProfile']
+> = ResolversObject<{
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
+  isAdmin?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
 export type Resolvers<ContextType = any> = ResolversObject<{
   Date?: GraphQLScalarType
   Location?: LocationResolvers<ContextType>
@@ -431,6 +448,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   Query?: QueryResolvers<ContextType>
   Mutation?: MutationResolvers<ContextType>
   Shipment?: ShipmentResolvers<ContextType>
+  UserProfile?: UserProfileResolvers<ContextType>
 }>
 
 /**

--- a/src/testServer.ts
+++ b/src/testServer.ts
@@ -3,25 +3,36 @@ import { createTestClient, ApolloServerTestClient } from 'apollo-server-testing'
 import { merge } from 'lodash'
 import { serverConfig } from './apolloServer'
 import { fakeUserAuth, fakeAdminAuth } from './authenticateRequest'
+import { sequelize } from './sequelize'
+import UserAccount from './models/user_account'
 
-export const makeTestServer = (
+const userAccountRepository = sequelize.getRepository(UserAccount)
+
+export const makeTestServer = async (
   overrides: Partial<ApolloServerExpressConfig> = {},
-): ApolloServerTestClient => {
-  const defaultOverrides = {
-    context: () => ({
-      auth: fakeUserAuth,
-    }),
+): Promise<ApolloServerTestClient> => {
+  if (overrides.context == null) {
+    const userAccount = await userAccountRepository.create({
+      auth0Id: 'user-auth0-id',
+    })
+
+    overrides.context = () => ({
+      auth: { ...fakeUserAuth, userAccount },
+    })
   }
 
-  return createTestClient(
-    new ApolloServer(merge(serverConfig, defaultOverrides, overrides)),
-  )
+  return createTestClient(new ApolloServer(merge(serverConfig, overrides)))
 }
 
-export const makeAdminTestServer = (
+export const makeAdminTestServer = async (
   overrides: Partial<ApolloServerExpressConfig> = {},
-) =>
-  makeTestServer({
-    context: () => ({ auth: fakeAdminAuth }),
+) => {
+  const userAccount = await userAccountRepository.create({
+    auth0Id: 'admin-auth0-id',
+  })
+
+  return makeTestServer({
+    context: () => ({ auth: { ...fakeAdminAuth, userAccount } }),
     ...overrides,
   })
+}

--- a/src/tests/groups_api.test.ts
+++ b/src/tests/groups_api.test.ts
@@ -6,7 +6,6 @@ import { sequelize } from '../sequelize'
 import Group from '../models/group'
 import { createGroup } from './helpers'
 import { GroupType } from '../server-internal-types'
-import { group } from '../resolvers/group'
 
 describe('Groups API', () => {
   let testServer: ApolloServerTestClient
@@ -20,12 +19,12 @@ describe('Groups API', () => {
   }
 
   beforeEach(async () => {
-    testServer = makeTestServer()
-
-    await sequelize.sync({ force: true })
     await sequelize
       .getRepository(Group)
       .truncate({ cascade: true, force: true })
+    await sequelize.sync({ force: true })
+
+    testServer = await makeTestServer()
   })
 
   describe('addGroup', () => {

--- a/src/tests/helpers/index.ts
+++ b/src/tests/helpers/index.ts
@@ -1,10 +1,19 @@
 import Group from '../../models/group'
 import Shipment from '../../models/shipment'
+import UserAccount from '../../models/user_account'
 import { sequelize } from '../../sequelize'
 import { GroupInput, ShipmentInput } from '../../server-internal-types'
 
+let fakeAuth0Id = 1
+
 async function createGroup(input: GroupInput): Promise<Group> {
-  return await sequelize.getRepository(Group).create(input)
+  const groupCaptain = await sequelize
+    .getRepository(UserAccount)
+    .create({ auth0Id: `fake-auth-id-${fakeAuth0Id++}` })
+
+  return await sequelize
+    .getRepository(Group)
+    .create({ ...input, captainId: groupCaptain.id })
 }
 
 async function createShipment(input: ShipmentInput): Promise<Shipment> {

--- a/src/tests/shipments_api.test.ts
+++ b/src/tests/shipments_api.test.ts
@@ -20,9 +20,6 @@ describe('Shipments API', () => {
     group2: Group
 
   beforeEach(async () => {
-    testServer = makeTestServer()
-    adminTestServer = makeAdminTestServer()
-
     await sequelize.sync({ force: true })
     await sequelize
       .getRepository(Group)
@@ -31,21 +28,24 @@ describe('Shipments API', () => {
       .getRepository(Shipment)
       .truncate({ cascade: true, force: true })
 
+    testServer = await makeTestServer()
+    adminTestServer = await makeAdminTestServer()
+
     group1 = await createGroup({
-        name: 'group 1',
-        groupType: GroupType.DaHub,
-        primaryLocation: { countryCode: "UK", townCity: "Bristol" },
-        primaryContact:  { name: "Contact", email: "contact@example.com" }
-      })
+      name: 'group 1',
+      groupType: GroupType.DaHub,
+      primaryLocation: { countryCode: 'UK', townCity: 'Bristol' },
+      primaryContact: { name: 'Contact', email: 'contact@example.com' },
+    })
     group2 = await createGroup({
-        name: 'group 2',
-        groupType: GroupType.ReceivingGroup,
-        primaryLocation: { countryCode: "FR", townCity: "Bordeaux" },
-        primaryContact:  {
-          name: "Second Contact",
-          email: "2ndcontact@example.com"
-        }
-      })
+      name: 'group 2',
+      groupType: GroupType.ReceivingGroup,
+      primaryLocation: { countryCode: 'FR', townCity: 'Bordeaux' },
+      primaryContact: {
+        name: 'Second Contact',
+        email: '2ndcontact@example.com',
+      },
+    })
   })
 
   describe('addShipment', () => {
@@ -122,7 +122,6 @@ describe('Shipments API', () => {
 
   describe('listShipments', () => {
     it('lists existing shipments', async () => {
-
       const shipment1 = await createShipment({
         shippingRoute: ShippingRoute.Uk,
         labelYear: 2020,


### PR DESCRIPTION
Since non-admins can create groups, we associate newly created groups with their creator as the group's captain.

Also made the profile endpoint return the user account ID and whether or not they're an admin. Over time we'll probably put other user-specific useful things for the UI in the profile.