### PR TITLE
Organize imports with the commit hook

### DIFF
--- a/frontend/src/pages/ApolloDemo.tsx
+++ b/frontend/src/pages/ApolloDemo.tsx
@@ -1,6 +1,5 @@
-import { useQuery, gql } from '@apollo/client'
+import { gql, useQuery } from '@apollo/client'
 import { useEffect } from 'react'
-
 import LayoutWithNav from '../layouts/LayoutWithNav'
 
 /**

--- a/frontend/src/pages/LoadingPage.tsx
+++ b/frontend/src/pages/LoadingPage.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react'
-import TopNavigation from '../components/TopNavigation'
 import Spinner from '../components/Spinner'
+import TopNavigation from '../components/TopNavigation'
 
 const LoadingPage: FunctionComponent = () => {
   return (

--- a/frontend/src/pages/groups/GroupCreatePage.tsx
+++ b/frontend/src/pages/groups/GroupCreatePage.tsx
@@ -1,9 +1,9 @@
 import { FunctionComponent } from 'react'
-import { gql, useMutation } from '@apollo/client'
 import { useHistory } from 'react-router-dom'
 import LayoutWithNav from '../../layouts/LayoutWithNav'
 import { Group, GroupInput } from '../../types/api-types'
 import GroupForm from './GroupForm'
+import { gql, useMutation, useQuery } from '@apollo/client'
 
 const ADD_GROUP = gql`
   mutation Groups($input: GroupInput!) {

--- a/frontend/src/pages/groups/GroupCreatePage.tsx
+++ b/frontend/src/pages/groups/GroupCreatePage.tsx
@@ -1,9 +1,9 @@
+import { gql, useMutation } from '@apollo/client'
 import { FunctionComponent } from 'react'
 import { useHistory } from 'react-router-dom'
 import LayoutWithNav from '../../layouts/LayoutWithNav'
 import { Group, GroupInput } from '../../types/api-types'
 import GroupForm from './GroupForm'
-import { gql, useMutation, useQuery } from '@apollo/client'
 
 const ADD_GROUP = gql`
   mutation Groups($input: GroupInput!) {

--- a/frontend/src/pages/groups/GroupEditPage.tsx
+++ b/frontend/src/pages/groups/GroupEditPage.tsx
@@ -1,5 +1,5 @@
-import { FunctionComponent } from 'react'
 import { gql, useQuery } from '@apollo/client'
+import { FunctionComponent } from 'react'
 import { useParams } from 'react-router-dom'
 import LayoutWithNav from '../../layouts/LayoutWithNav'
 import { Group, GroupInput } from '../../types/api-types'

--- a/frontend/src/pages/groups/GroupForm.tsx
+++ b/frontend/src/pages/groups/GroupForm.tsx
@@ -1,9 +1,9 @@
 import { FunctionComponent, ReactNode, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
-import { Group, GroupInput, GroupType } from '../../types/api-types'
-import TextField from '../../components/forms/TextField'
-import SelectField from '../../components/forms/SelectField'
 import Button from '../../components/Button'
+import SelectField from '../../components/forms/SelectField'
+import TextField from '../../components/forms/TextField'
+import { Group, GroupInput, GroupType } from '../../types/api-types'
 
 interface Props {
   /**

--- a/frontend/src/pages/groups/GroupList.tsx
+++ b/frontend/src/pages/groups/GroupList.tsx
@@ -1,11 +1,11 @@
-import { FunctionComponent, useMemo } from 'react'
-import { useSortBy, useTable } from 'react-table'
-import cx from 'classnames'
-import LayoutWithNav from '../../layouts/LayoutWithNav'
-import { formatGroupType } from '../../utils/format'
 import { gql, useQuery } from '@apollo/client'
-import { Group } from '../../types/api-types'
+import cx from 'classnames'
+import { FunctionComponent, useMemo } from 'react'
 import { Link } from 'react-router-dom'
+import { useSortBy, useTable } from 'react-table'
+import LayoutWithNav from '../../layouts/LayoutWithNav'
+import { Group } from '../../types/api-types'
+import { formatGroupType } from '../../utils/format'
 
 const GROUPS_QUERY = gql`
   query GetAllGroups {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ncp": "^2.0.0",
     "nodemon": "^2.0.7",
     "pg": "^8.5.1",
+    "prettier-plugin-organize-imports": "^1.1.1",
     "react-hook-form": "^6.15.4",
     "reflect-metadata": "^0.1.13",
     "sequelize": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6714,6 +6714,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier-plugin-organize-imports@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-1.1.1.tgz#7f1ac1a13d4d1752dc16881894dde1c10ccbf3c0"
+  integrity sha512-rFA1lnek1FYkMGthm4xBKME41qUKItTovuo24bCGZu/Vu1n3gW71UPLAkIdwewwkZCe29gRVweSOPXvAdckFuw==
+
 prettier@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz"


### PR DESCRIPTION
Bion suggested sorting imports in a previous PR, and I wanted to automate that process.

This PR adds the `prettier-plugin-organize-imports` package, which will automagically be loaded by Prettier when running the commit hook.