### PR TITLE
Display a list of all shipments

### DIFF
--- a/frontend/src/AppRoot.tsx
+++ b/frontend/src/AppRoot.tsx
@@ -12,6 +12,7 @@ import HomePage from './pages/Home'
 import LoadingPage from './pages/LoadingPage'
 import NotFoundPage from './pages/NotFoundPage'
 import PublicHomePage from './pages/PublicHome'
+import ShipmentList from './pages/shipments/ShipmentList'
 import ROUTES from './utils/routes'
 
 const fetchProfile = (token: string) => {
@@ -62,24 +63,27 @@ const AppRoot = () => {
           </Route>
           <PrivateRoute
             path={ROUTES.GROUP_LIST}
-            exact
             isAuthenticated={isAuthenticated}
           >
             <GroupList />
           </PrivateRoute>
           <PrivateRoute
             path={ROUTES.GROUP_CREATE}
-            exact
             isAuthenticated={isAuthenticated}
           >
             <GroupCreatePage />
           </PrivateRoute>
           <PrivateRoute
             path={ROUTES.GROUP_EDIT}
-            exact
             isAuthenticated={isAuthenticated}
           >
             <GroupEditPage />
+          </PrivateRoute>
+          <PrivateRoute
+            path={ROUTES.SHIPMENT_LIST}
+            isAuthenticated={isAuthenticated}
+          >
+            <ShipmentList />
           </PrivateRoute>
           <PrivateRoute isAuthenticated={isAuthenticated} path="*">
             <NotFoundPage />

--- a/frontend/src/components/Badge.tsx
+++ b/frontend/src/components/Badge.tsx
@@ -1,0 +1,31 @@
+import cx from 'classnames'
+import { FunctionComponent } from 'react'
+
+export type BadgeColor =
+  | 'red'
+  | 'navy'
+  | 'blue'
+  | 'green'
+  | 'gray'
+  | 'yellow'
+  | 'purple'
+
+interface Props {
+  color?: BadgeColor
+}
+
+const Badge: FunctionComponent<Props> = ({ color = 'gray', children }) => {
+  const classes = cx('rounded-sm py-1 px-2 text-sm font-semibold', {
+    'bg-red-100 text-red-700': color === 'red',
+    'bg-da-navy-500 text-da-navy-50': color === 'navy',
+    'bg-blue-100 text-blue-700': color === 'blue',
+    'bg-green-100 text-green-700': color === 'green',
+    'bg-gray-100 text-gray-700': color === 'gray',
+    'bg-yellow-100 text-yellow-700': color === 'yellow',
+    'bg-purple-100 text-purple-700': color === 'purple',
+  })
+
+  return <span className={classes}>{children}</span>
+}
+
+export default Badge

--- a/frontend/src/components/table/TableHeader.tsx
+++ b/frontend/src/components/table/TableHeader.tsx
@@ -1,0 +1,41 @@
+import cx from 'classnames'
+import { FunctionComponent, ThHTMLAttributes } from 'react'
+
+interface Props extends ThHTMLAttributes<HTMLTableHeaderCellElement> {
+  canSort?: boolean
+  isSorted?: boolean
+  isSortedDesc?: boolean
+}
+
+/**
+ * A <th> element augmented with styling and a representation of sort status.
+ */
+const TableHeader: FunctionComponent<Props> = ({
+  children,
+  canSort,
+  isSorted,
+  isSortedDesc,
+  ...otherProps
+}) => {
+  return (
+    <th
+      className={cx(
+        'p-2 first:pl-6 last:pr-6 bg-gray-50 text-gray-700 text-left font-semibold',
+        {
+          'hover:bg-gray-100': canSort,
+          'bg-gray-100': isSorted,
+        },
+      )}
+      {...otherProps}
+    >
+      {children}
+      {canSort && (
+        <span className="ml-2 inline-block text-gray-500 w-2">
+          {isSorted ? (isSortedDesc ? '↓' : '↑') : ''}
+        </span>
+      )}
+    </th>
+  )
+}
+
+export default TableHeader

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,4 +1,5 @@
-import { GroupType } from '../types/api-types'
+import { BadgeColor } from '../components/Badge'
+import { GroupType, ShipmentStatus } from '../types/api-types'
 
 export function formatGroupType(type: GroupType) {
   switch (type) {
@@ -10,5 +11,51 @@ export function formatGroupType(type: GroupType) {
       return 'Sending group'
     default:
       throw new Error(`Unknown GroupType: ${type}`)
+  }
+}
+
+/**
+ * Format a month's 1-based number into a string.
+ * @param labelMonth a Shipment.labelMonth
+ * @example formatLabelMonth(1) // January
+ */
+export function formatLabelMonth(labelMonth: number) {
+  return [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ][labelMonth - 1]
+}
+
+/**
+ * Returns a BadgeColor based mapped to a ShipmentStatus
+ * @param status a ShipmentStatus
+ */
+export function getShipmentStatusBadgeColor(
+  status: ShipmentStatus,
+): BadgeColor {
+  switch (status) {
+    case ShipmentStatus.Abandoned:
+      return 'red'
+    case ShipmentStatus.Announced:
+      return 'blue'
+    case ShipmentStatus.Complete:
+      return 'green'
+    case ShipmentStatus.InProgress:
+      return 'blue'
+    case ShipmentStatus.Open:
+      return 'yellow'
+    case ShipmentStatus.Staging:
+    default:
+      return 'gray'
   }
 }

--- a/frontend/src/utils/routes.ts
+++ b/frontend/src/utils/routes.ts
@@ -5,6 +5,7 @@ const ROUTES = {
   GROUP_LIST: '/groups',
   GROUP_CREATE: '/group/new',
   GROUP_EDIT: '/group/:groupId',
+  SHIPMENT_LIST: '/shipments',
 }
 
 export default ROUTES


### PR DESCRIPTION
### Changes

- added a new `/shipments` page where we display a list of shipments
- added a `<Badge>` component
- added a `<TableHeader>` component to abstract away some reused code
- added some formatting functions that I expect we'll reuse soon

### Pixels

<img width="500" alt="Screen Shot 2021-03-10 at 8 16 57 PM" src="https://user-images.githubusercontent.com/3411183/110735035-d9659200-81dd-11eb-9f36-42ae3c450180.png">

Resolves #30