### PR TITLE
Fixed static asset paths in the Express server

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,3 +1,2 @@
-# https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,2 +1,3 @@
+# https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow: /
+Disallow:

--- a/src/getAllFilesSync.ts
+++ b/src/getAllFilesSync.ts
@@ -1,21 +1,24 @@
 import fs from 'fs'
 import path from 'path'
 
-const getAllFilesSync = function (
-  dirPath: string,
-  fileCollection: string[] = [],
-) {
-  const files: string[] = fs.readdirSync(dirPath)
+const getAllFilesSync = function (rootPath: string) {
+  function listFiles(dirPath: string, fileCollection: string[] = []) {
+    const files: string[] = fs.readdirSync(dirPath)
 
-  files.forEach(function (file: string) {
-    if (fs.statSync(dirPath + '/' + file).isDirectory()) {
-      fileCollection = getAllFilesSync(dirPath + '/' + file, fileCollection)
-    } else {
-      fileCollection.push(path.join(__dirname, dirPath, '/', file))
-    }
-  })
+    files.forEach(function (file: string) {
+      if (fs.statSync(dirPath + '/' + file).isDirectory()) {
+        fileCollection = listFiles(path.join(dirPath, file), fileCollection)
+      } else {
+        fileCollection.push(
+          '/' + path.relative(rootPath, path.join(dirPath, file)),
+        )
+      }
+    })
 
-  return fileCollection
+    return fileCollection
+  }
+
+  return listFiles(rootPath)
 }
 
 export default getAllFilesSync

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,7 +35,7 @@ const PUBLIC_DIR = path.join(__dirname, '../frontend/build')
 
 // Serve static assets for the frontend
 getAllFilesSync(PUBLIC_DIR).forEach((file: string) => {
-  file = file.replace(/^[\\/A-Za-z0-9]+frontend\/build/i, '')
+  console.log(file)
   app.get(file, (req, res) => {
     res.sendFile(path.join(PUBLIC_DIR, file))
   })

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,7 +35,6 @@ const PUBLIC_DIR = path.join(__dirname, '../frontend/build')
 
 // Serve static assets for the frontend
 getAllFilesSync(PUBLIC_DIR).forEach((file: string) => {
-  console.log(file)
   app.get(file, (req, res) => {
     res.sendFile(path.join(PUBLIC_DIR, file))
   })


### PR DESCRIPTION
I was trying to get the `robots.txt` file to be server by Express and realized that the existing code should already be doing it. The issue was the list of paths returned by `getAllFilesSync()`.

It looked like this (note the duplicate path):

```
/Users/maxime/shipment-tracker/src/Users/maxime/shipment-tracker/frontend/build/asset-manifest.json
/Users/maxime/shipment-tracker/src/Users/maxime/shipment-tracker/frontend/build/index.html
/Users/maxime/shipment-tracker/src/Users/maxime/shipment-tracker/frontend/build/manifest.json
/Users/maxime/shipment-tracker/src/Users/maxime/shipment-tracker/frontend/build/robots.txt
/Users/maxime/shipment-tracker/src/Users/maxime/shipment-tracker/frontend/build/static/css/main.6817bdc5.chunk.css
/Users/maxime/shipment-tracker/src/Users/maxime/shipment-tracker/frontend/build/static/css/main.6817bdc5.chunk.css.map
/Users/maxime/shipment-tracker/src/Users/maxime/shipment-tracker/frontend/build/static/js/2.809e6175.chunk.js
/Users/maxime/shipment-tracker/src/Users/maxime/shipment-tracker/frontend/build/static/js/2.809e6175.chunk.js.LICENSE.txt
...
```

What we really want is:

```
/asset-manifest.json
/index.html
/manifest.json
/robots.txt
/static/css/main.6817bdc5.chunk.css
/static/css/main.6817bdc5.chunk.css.map
/static/js/2.809e6175.chunk.js
/static/js/2.809e6175.chunk.js.LICENSE.txt
...
```

### Testing

Check out this branch and run the server locally. You should see the contents of the `/robots.txt` file at the URL below:
http://localhost:3000/robots.txt