### PR TITLE
Fix auth for local development

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,5 +51,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "http://localhost:3000"
 }


### PR DESCRIPTION
Without the proxy configured in the react dev server, the dev server would serve the react app for GET requests to `/profile`. This breaks auth for local development when running the react dev server because fetching `/profile` creates a user account for the authenticated user if they don't have one yet.