### PR TITLE
Added a page to edit existing shipments

### DIFF
--- a/frontend/src/AppRoot.tsx
+++ b/frontend/src/AppRoot.tsx
@@ -13,6 +13,7 @@ import KitchenSink from './pages/KitchenSink'
 import LoadingPage from './pages/LoadingPage'
 import NotFoundPage from './pages/NotFoundPage'
 import PublicHomePage from './pages/PublicHome'
+import ShipmentEditPage from './pages/shipments/ShipmentEditPage'
 import ShipmentList from './pages/shipments/ShipmentList'
 import ROUTES from './utils/routes'
 
@@ -92,6 +93,12 @@ const AppRoot = () => {
             isAuthenticated={isAuthenticated}
           >
             <ShipmentList />
+          </PrivateRoute>
+          <PrivateRoute
+            path={ROUTES.SHIPMENT_EDIT}
+            isAuthenticated={isAuthenticated}
+          >
+            <ShipmentEditPage />
           </PrivateRoute>
           <PrivateRoute isAuthenticated={isAuthenticated} path="*">
             <NotFoundPage />

--- a/frontend/src/components/forms/SelectField.tsx
+++ b/frontend/src/components/forms/SelectField.tsx
@@ -1,15 +1,15 @@
-import {
-  FunctionComponent,
-  useState,
-  ReactNode,
-  ChangeEvent,
-  InputHTMLAttributes,
-} from 'react'
 import { nanoid } from 'nanoid'
-import SelectInput from './SelectInput'
-import Label from './Label'
-import InlineError from './InlineError'
+import {
+  ChangeEvent,
+  FunctionComponent,
+  ReactNode,
+  SelectHTMLAttributes,
+  useState,
+} from 'react'
 import { FormRegisterType } from '../../types/form-types'
+import InlineError from './InlineError'
+import Label from './Label'
+import SelectInput from './SelectInput'
 
 export interface SelectOption {
   label: ReactNode
@@ -17,7 +17,7 @@ export interface SelectOption {
   disabled?: boolean
 }
 
-type Props = InputHTMLAttributes<HTMLSelectElement> & {
+type Props = SelectHTMLAttributes<HTMLSelectElement> & {
   /**
    * The ID of the input, used to map the label to the input element
    */
@@ -61,6 +61,10 @@ type Props = InputHTMLAttributes<HTMLSelectElement> & {
    * The register function from `react-hook-form`'s `useForm()` hook used for validation and submission
    */
   register?: FormRegisterType
+  /**
+   * If true, the value of each option will be cast to a number using parseInt()
+   */
+  castAsNumber?: boolean
 }
 
 const SelectField: FunctionComponent<Props> = ({

--- a/frontend/src/components/forms/SelectInput.tsx
+++ b/frontend/src/components/forms/SelectInput.tsx
@@ -1,36 +1,47 @@
 import cx from 'classnames'
-import { FunctionComponent, InputHTMLAttributes } from 'react'
+import { FunctionComponent, SelectHTMLAttributes } from 'react'
+import { RegisterOptions } from 'react-hook-form'
 import { FormRegisterType } from '../../types/form-types'
 
-type Props = InputHTMLAttributes<HTMLSelectElement> & {
+type Props = SelectHTMLAttributes<HTMLSelectElement> & {
   /**
    * If true, the field will be displayed with a red border
    */
   hasError?: boolean
   /**
-   * The register function from `react-hook-form`'s `useForm()` hook used for validation and submission
+   * The register function from `react-hook-form`'s `useForm()` hook used for
+   * validation and submission
    */
   register?: FormRegisterType
+  /**
+   * If true, the value of each option will be cast to a number using parseInt()
+   */
+  castAsNumber?: boolean
 }
 
 const SelectInput: FunctionComponent<Props> = ({
   hasError = false,
   register,
+  castAsNumber,
   ...otherProps
 }) => {
-  const { disabled, readOnly, className, children } = otherProps
+  const { disabled, className, children } = otherProps
 
   const classes = cx(
     className,
     'appearance-none w-full border px-3 py-2 rounded transition focus:outline-none focus:shadow-outline focus:ring ring-navy-300 focus:border-navy-600',
     {
-      'border-gray-300 hover:border-gray-400':
-        !hasError && !readOnly && !disabled,
+      'border-gray-300 hover:border-gray-400': !hasError && !disabled,
       'border-red-400': hasError,
-      'bg-gray-100': readOnly || disabled,
+      'bg-gray-100': disabled,
       'cursor-not-allowed': disabled,
     },
   )
+
+  const registerOptions: RegisterOptions = {
+    required: otherProps.required,
+    valueAsNumber: castAsNumber,
+  }
 
   return (
     <select
@@ -42,7 +53,7 @@ const SelectInput: FunctionComponent<Props> = ({
         backgroundSize: '1.5em 1.5em',
       }}
       className={classes}
-      ref={register ? register({ required: otherProps.required }) : undefined}
+      ref={register ? register(registerOptions) : undefined}
     >
       {children}
     </select>

--- a/frontend/src/components/forms/TextInput.tsx
+++ b/frontend/src/components/forms/TextInput.tsx
@@ -1,5 +1,6 @@
 import cx from 'classnames'
 import { FunctionComponent, InputHTMLAttributes } from 'react'
+import { RegisterOptions } from 'react-hook-form'
 import { FormRegisterType } from '../../types/form-types'
 
 type Props = InputHTMLAttributes<HTMLInputElement> & {
@@ -33,10 +34,15 @@ const TextInput: FunctionComponent<Props> = ({
     },
   )
 
+  const registerOptions: RegisterOptions = {
+    required: otherProps.required,
+    valueAsNumber: type === 'number',
+  }
+
   return (
     <input
       {...otherProps}
-      ref={register ? register({ required: otherProps.required }) : undefined}
+      ref={register ? register(registerOptions) : undefined}
       type={type}
       className={classes}
     />

--- a/frontend/src/data/constants.ts
+++ b/frontend/src/data/constants.ts
@@ -1,0 +1,23 @@
+export const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
+/**
+ * A value + label pair of months for use in Select fields.
+ * Note that the value starts at 1 (January)
+ */
+export const MONTH_OPTIONS = MONTHS.map((month, index) => ({
+  label: month,
+  value: index + 1,
+}))

--- a/frontend/src/pages/groups/GroupEditPage.tsx
+++ b/frontend/src/pages/groups/GroupEditPage.tsx
@@ -44,7 +44,7 @@ const GET_GROUP = gql`
 // `
 
 const GroupEditPage: FunctionComponent = () => {
-  // Extract the group's ID from teh URL
+  // Extract the group's ID from the URL
   const { groupId } = useParams<{ groupId: string }>()
 
   // Load the group's information

--- a/frontend/src/pages/groups/GroupList.tsx
+++ b/frontend/src/pages/groups/GroupList.tsx
@@ -102,7 +102,7 @@ const GroupList: FunctionComponent = () => {
                       <td
                         {...cell.getCellProps()}
                         className={cx('p-2 first:pl-6 last:pr-6', {
-                          'font-semibold text-navy-800':
+                          'font-semibold text-navy-700 hover:underline':
                             cell.column.Header === 'Name',
                           'bg-gray-50': cell.column.isSorted,
                         })}

--- a/frontend/src/pages/groups/GroupList.tsx
+++ b/frontend/src/pages/groups/GroupList.tsx
@@ -8,6 +8,7 @@ import TableHeader from '../../components/table/TableHeader'
 import LayoutWithNav from '../../layouts/LayoutWithNav'
 import { Group } from '../../types/api-types'
 import { formatGroupType } from '../../utils/format'
+import ROUTES, { groupEditRoute } from '../../utils/routes'
 
 const GROUPS_QUERY = gql`
   query GetAllGroups {
@@ -69,7 +70,7 @@ const GroupList: FunctionComponent = () => {
       <div className="max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content">
         <header className="p-6 border-b border-gray-200 flex items-center justify-between">
           <h1 className="text-navy-800 text-3xl">Groups</h1>
-          <ButtonLink to="/group/new">Create a group</ButtonLink>
+          <ButtonLink to={ROUTES.GROUP_CREATE}>Create a group</ButtonLink>
         </header>
         <main>
           <table className="w-full" {...getTableProps()}>
@@ -108,7 +109,7 @@ const GroupList: FunctionComponent = () => {
                         })}
                       >
                         {cell.column.Header === 'Name' ? (
-                          <Link to={`/group/${row.original.id}`}>
+                          <Link to={groupEditRoute(row.original.id)}>
                             {cell.render('Cell')}
                           </Link>
                         ) : (

--- a/frontend/src/pages/shipments/ShipmentEditPage.tsx
+++ b/frontend/src/pages/shipments/ShipmentEditPage.tsx
@@ -1,0 +1,86 @@
+import { gql, useMutation, useQuery } from '@apollo/client'
+import { FunctionComponent } from 'react'
+import { useParams } from 'react-router-dom'
+import LayoutWithNav from '../../layouts/LayoutWithNav'
+import { Shipment, ShipmentUpdateInput } from '../../types/api-types'
+import { formatShipmentName } from '../../utils/format'
+import ShipmentForm from './ShipmentForm'
+
+const ALL_SHIPMENT_FIELDS = gql`
+  fragment AllShipmentFields on Shipment {
+    id
+    shippingRoute
+    labelYear
+    labelMonth
+    offerSubmissionDeadline
+    status
+  }
+`
+
+const GET_SHIPMENT = gql`
+  ${ALL_SHIPMENT_FIELDS}
+  query Shipment($id: Int!) {
+    shipment(id: $id) {
+      ...AllShipmentFields
+    }
+  }
+`
+
+const UPDATE_SHIPMENT_MUTATION = gql`
+  ${ALL_SHIPMENT_FIELDS}
+  mutation Shipment($id: Int!, $input: ShipmentUpdateInput!) {
+    updateShipment(id: $id, input: $input) {
+      ...AllShipmentFields
+    }
+  }
+`
+
+const ShipmentEditPage: FunctionComponent = () => {
+  // Extract the shipment's ID from the URL
+  const { shipmentId } = useParams<{ shipmentId: string }>()
+
+  // Load the shipment's information
+  const { data: originalShipmentData, loading: queryIsLoading } = useQuery<{
+    shipment: Shipment
+  }>(GET_SHIPMENT, {
+    variables: { id: parseInt(shipmentId, 10) },
+  })
+
+  // Set up the mutation to update the shipment
+  const [updateShipment, { loading: mutationIsLoading }] = useMutation(
+    UPDATE_SHIPMENT_MUTATION,
+  )
+
+  const onSubmit = (input: ShipmentUpdateInput) => {
+    updateShipment({
+      variables: { id: parseInt(shipmentId, 10), input },
+    }).catch((error) => {
+      console.log(error)
+    })
+  }
+
+  return (
+    <LayoutWithNav>
+      <div className="max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content">
+        <header className="p-4 md:p-6 border-b border-gray-200">
+          <h1 className="text-navy-800 text-3xl mb-2">
+            {originalShipmentData
+              ? formatShipmentName(originalShipmentData.shipment)
+              : 'Shipment'}
+          </h1>
+          <p className="text-gray-700">TODO describe what a shipment is</p>
+        </header>
+        <main className="p-4 md:p-6 max-w-lg pb-20">
+          <ShipmentForm
+            isLoading={queryIsLoading || mutationIsLoading}
+            submitButtonLabel="Save changes"
+            onSubmit={onSubmit}
+            defaultValues={originalShipmentData?.shipment}
+          />
+        </main>
+      </div>
+    </LayoutWithNav>
+  )
+}
+
+export default ShipmentEditPage

--- a/frontend/src/pages/shipments/ShipmentEditPage.tsx
+++ b/frontend/src/pages/shipments/ShipmentEditPage.tsx
@@ -68,7 +68,6 @@ const ShipmentEditPage: FunctionComponent = () => {
               ? formatShipmentName(originalShipmentData.shipment)
               : 'Shipment'}
           </h1>
-          <p className="text-gray-700">TODO describe what a shipment is</p>
         </header>
         <main className="p-4 md:p-6 max-w-lg pb-20">
           <ShipmentForm

--- a/frontend/src/pages/shipments/ShipmentForm.tsx
+++ b/frontend/src/pages/shipments/ShipmentForm.tsx
@@ -1,0 +1,169 @@
+import { gql, useQuery } from '@apollo/client'
+import React, { FunctionComponent, ReactNode, useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import Button from '../../components/Button'
+import SelectField, { SelectOption } from '../../components/forms/SelectField'
+import TextField from '../../components/forms/TextField'
+import { MONTH_OPTIONS } from '../../data/constants'
+import {
+  Group,
+  GroupType,
+  Shipment,
+  ShipmentStatus,
+  ShipmentUpdateInput,
+  ShippingRoute,
+} from '../../types/api-types'
+
+interface Props {
+  /**
+   * If true, the Submit button will be disabled
+   */
+  isLoading: boolean
+  /**
+   * The text to display in the Submit button of the form
+   */
+  submitButtonLabel: ReactNode
+  /**
+   * The values to display in the fields of the form. Note that this is NOT a
+   * controlled component.
+   */
+  defaultValues?: Shipment
+  /**
+   * The callback triggered when the user submits the form
+   */
+  onSubmit: (input: ShipmentUpdateInput) => void
+}
+
+const STATUS_OPTIONS = [
+  { label: 'Abandoned', value: ShipmentStatus.Abandoned },
+  { label: 'Announced', value: ShipmentStatus.Announced },
+  { label: 'Complete', value: ShipmentStatus.Complete },
+  { label: 'In progress', value: ShipmentStatus.InProgress },
+  { label: 'Open', value: ShipmentStatus.Open },
+  { label: 'In staging', value: ShipmentStatus.Staging },
+]
+
+const SHIPPING_ROUTE_OPTIONS = Object.keys(ShippingRoute).map((routeKey) => ({
+  label: (ShippingRoute as any)[routeKey],
+  value: (ShippingRoute as any)[routeKey],
+}))
+
+const GET_ALL_GROUPS = gql`
+  query Groups {
+    listGroups {
+      id
+      name
+      groupType
+    }
+  }
+`
+
+function groupToSelectOption(group: Group): SelectOption {
+  return { value: group.id, label: group.name }
+}
+
+const ShipmentForm: FunctionComponent<Props> = (props) => {
+  const [receivingGroups, setReceivingGroups] = useState<SelectOption[]>([])
+  const [sendingGroups, setSendingGroups] = useState<SelectOption[]>([])
+
+  // Load the list of groups
+  const { data: hubs, loading: hubListIsLoading } = useQuery<{
+    listGroups: Group[]
+  }>(GET_ALL_GROUPS)
+
+  // When the groups are loaded, organize them by type so we can present them
+  // in the form
+  useEffect(
+    function organizeGroups() {
+      if (hubs && hubs.listGroups) {
+        setReceivingGroups(
+          hubs.listGroups
+            .filter((group) => group.groupType === GroupType.ReceivingGroup)
+            .map(groupToSelectOption),
+        )
+        setSendingGroups(
+          hubs.listGroups
+            .filter((group) => group.groupType === GroupType.SendingGroup)
+            .map(groupToSelectOption),
+        )
+      }
+    },
+    [hubListIsLoading, hubs],
+  )
+
+  const { register, handleSubmit, reset } = useForm()
+
+  useEffect(
+    function resetFormValues() {
+      if (props.defaultValues) {
+        console.log(props.defaultValues)
+
+        // Update the values of the fields
+        reset(props.defaultValues)
+      }
+    },
+    [props.defaultValues, reset],
+  )
+
+  return (
+    <form onSubmit={handleSubmit(props.onSubmit)} className="space-y-4">
+      <SelectField
+        options={STATUS_OPTIONS}
+        label="Status"
+        name="status"
+        register={register}
+        required
+      />
+      <SelectField
+        options={SHIPPING_ROUTE_OPTIONS}
+        label="Shipping route"
+        name="shippingRoute"
+        register={register}
+        required
+      />
+      <div className="flex space-x-4">
+        <SelectField
+          options={MONTH_OPTIONS}
+          label="Label month"
+          name="labelMonth"
+          castAsNumber
+          register={register}
+          required
+        />
+        <TextField
+          label="Label year"
+          name="labelYear"
+          register={register}
+          required
+          type="number"
+          minLength={4}
+          maxLength={4}
+        />
+      </div>
+      <SelectField
+        label="Sending hub"
+        name="sendingHubId"
+        options={sendingGroups}
+        castAsNumber
+        register={register}
+        required
+        disabled={hubListIsLoading}
+      />
+      <SelectField
+        label="Receiving hub"
+        name="receivingHubId"
+        options={receivingGroups}
+        castAsNumber
+        register={register}
+        required
+        disabled={hubListIsLoading}
+      />
+
+      <Button variant="primary" type="submit" disabled={props.isLoading}>
+        {props.submitButtonLabel}
+      </Button>
+    </form>
+  )
+}
+
+export default ShipmentForm

--- a/frontend/src/pages/shipments/ShipmentForm.tsx
+++ b/frontend/src/pages/shipments/ShipmentForm.tsx
@@ -13,6 +13,7 @@ import {
   ShipmentUpdateInput,
   ShippingRoute,
 } from '../../types/api-types'
+import { enumValues } from '../../utils/types'
 
 interface Props {
   /**
@@ -43,9 +44,9 @@ const STATUS_OPTIONS = [
   { label: 'In staging', value: ShipmentStatus.Staging },
 ]
 
-const SHIPPING_ROUTE_OPTIONS = Object.keys(ShippingRoute).map((routeKey) => ({
-  label: (ShippingRoute as any)[routeKey],
-  value: (ShippingRoute as any)[routeKey],
+const SHIPPING_ROUTE_OPTIONS = enumValues(ShippingRoute).map((routeKey) => ({
+  label: routeKey,
+  value: routeKey,
 }))
 
 const GET_ALL_GROUPS = gql`
@@ -96,8 +97,6 @@ const ShipmentForm: FunctionComponent<Props> = (props) => {
   useEffect(
     function resetFormValues() {
       if (props.defaultValues) {
-        console.log(props.defaultValues)
-
         // Update the values of the fields
         reset(props.defaultValues)
       }

--- a/frontend/src/pages/shipments/ShipmentList.tsx
+++ b/frontend/src/pages/shipments/ShipmentList.tsx
@@ -1,13 +1,15 @@
 import { gql, useQuery } from '@apollo/client'
 import cx from 'classnames'
-import React, { FunctionComponent, useMemo } from 'react'
-import { useSortBy, useTable } from 'react-table'
+import { FunctionComponent, useMemo } from 'react'
+import { Link } from 'react-router-dom'
+import { Column, useSortBy, useTable } from 'react-table'
 import Badge from '../../components/Badge'
 import TableHeader from '../../components/table/TableHeader'
 import LayoutWithNav from '../../layouts/LayoutWithNav'
 import { Shipment } from '../../types/api-types'
 import {
   formatLabelMonth,
+  formatShipmentName,
   getShipmentStatusBadgeColor,
 } from '../../utils/format'
 
@@ -33,10 +35,10 @@ const SHIPMENTS_QUERY = gql`
   }
 `
 
-const COLUMNS = [
+const COLUMNS: Column<Shipment>[] = [
   {
-    Header: 'ID',
-    accessor: 'id',
+    Header: 'Name',
+    accessor: (row) => formatShipmentName(row),
   },
   {
     Header: 'Route',
@@ -44,16 +46,15 @@ const COLUMNS = [
   },
   {
     Header: 'Sending hub',
-    accessor: 'sendingHub.name',
+    accessor: (row) => row.sendingHub.name,
   },
   {
     Header: 'Receiving hub',
-    accessor: 'receivingHub.name',
+    accessor: (row) => row.receivingHub.name,
   },
   {
     Header: 'Date',
-    accessor: (row: Shipment) =>
-      `${formatLabelMonth(row.labelMonth)} ${row.labelYear}`,
+    accessor: (row) => `${formatLabelMonth(row.labelMonth)} ${row.labelYear}`,
   },
   {
     Header: 'Status',
@@ -76,7 +77,7 @@ const ShipmentList: FunctionComponent = () => {
     headerGroups,
     rows,
     prepareRow,
-  } = useTable({ columns: COLUMNS as any, data: shipments }, useSortBy)
+  } = useTable({ columns: COLUMNS, data: shipments }, useSortBy)
 
   return (
     <LayoutWithNav>
@@ -115,10 +116,18 @@ const ShipmentList: FunctionComponent = () => {
                       <td
                         {...cell.getCellProps()}
                         className={cx('p-2 first:pl-6 last:pr-6', {
+                          'font-semibold text-navy-700 hover:underline':
+                            cell.column.Header === 'Name',
                           'bg-gray-50': cell.column.isSorted,
                         })}
                       >
-                        {cell.render('Cell')}
+                        {cell.column.Header === 'Name' ? (
+                          <Link to={`/shipment/${row.original.id}`}>
+                            {cell.render('Cell')}
+                          </Link>
+                        ) : (
+                          cell.render('Cell')
+                        )}
                       </td>
                     ))}
                   </tr>

--- a/frontend/src/pages/shipments/ShipmentList.tsx
+++ b/frontend/src/pages/shipments/ShipmentList.tsx
@@ -12,6 +12,7 @@ import {
   formatShipmentName,
   getShipmentStatusBadgeColor,
 } from '../../utils/format'
+import { shipmentEditRoute } from '../../utils/routes'
 
 const SHIPMENTS_QUERY = gql`
   query GetAllShipments {
@@ -122,7 +123,7 @@ const ShipmentList: FunctionComponent = () => {
                         })}
                       >
                         {cell.column.Header === 'Name' ? (
-                          <Link to={`/shipment/${row.original.id}`}>
+                          <Link to={shipmentEditRoute(row.original.id)}>
                             {cell.render('Cell')}
                           </Link>
                         ) : (

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,5 +1,6 @@
 import { BadgeColor } from '../components/Badge'
-import { GroupType, ShipmentStatus } from '../types/api-types'
+import { MONTHS } from '../data/constants'
+import { GroupType, Shipment, ShipmentStatus } from '../types/api-types'
 
 export function formatGroupType(type: GroupType) {
   switch (type) {
@@ -20,20 +21,7 @@ export function formatGroupType(type: GroupType) {
  * @example formatLabelMonth(1) // January
  */
 export function formatLabelMonth(labelMonth: number) {
-  return [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ][labelMonth - 1]
+  return MONTHS[labelMonth - 1]
 }
 
 /**
@@ -58,4 +46,16 @@ export function getShipmentStatusBadgeColor(
     default:
       return 'gray'
   }
+}
+
+/**
+ * Formats a shipment name for quick identification. Note that this is NOT a
+ * unique identifier!
+ * @param shipment
+ * @returns A non-unique identifier for the shipment
+ * @example "UK-2021-03"
+ */
+export function formatShipmentName(shipment: Shipment) {
+  const month = shipment.labelMonth.toString().padStart(2, '0')
+  return `${shipment.shippingRoute}-${shipment.labelYear}-${month}`
 }

--- a/frontend/src/utils/routes.ts
+++ b/frontend/src/utils/routes.ts
@@ -6,6 +6,7 @@ const ROUTES = {
   GROUP_CREATE: '/group/new',
   GROUP_EDIT: '/group/:groupId',
   SHIPMENT_LIST: '/shipments',
+  SHIPMENT_EDIT: '/shipment/:shipmentId',
   KITCHEN_SINK: '/kitchen-sink',
 }
 

--- a/frontend/src/utils/routes.ts
+++ b/frontend/src/utils/routes.ts
@@ -4,10 +4,18 @@ const ROUTES = {
   APOLLO_DEMO: '/apollo-demo',
   GROUP_LIST: '/groups',
   GROUP_CREATE: '/group/new',
-  GROUP_EDIT: '/group/:groupId',
+  GROUP_EDIT: '/group/:groupId/edit',
   SHIPMENT_LIST: '/shipments',
-  SHIPMENT_EDIT: '/shipment/:shipmentId',
+  SHIPMENT_EDIT: '/shipment/:shipmentId/edit',
   KITCHEN_SINK: '/kitchen-sink',
+}
+
+export function groupEditRoute(groupId: number | string) {
+  return ROUTES.GROUP_EDIT.replace(':groupId', groupId.toString())
+}
+
+export function shipmentEditRoute(shipmentId: number | string) {
+  return ROUTES.SHIPMENT_EDIT.replace(':shipmentId', shipmentId.toString())
 }
 
 export default ROUTES

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Returns an array with all the keys in an enum
+ * @example
+ * enum Status {
+ *   InProgress = 'IN_PROGRESS',
+ *   Complete = 'COMPLETE',
+ * }
+ * enumKeys(Status) // ['InProgress', 'Complete']
+ */
+export function enumKeys<O extends object, K extends keyof O = keyof O>(
+  obj: O,
+): K[] {
+  return Object.keys(obj) as K[]
+}
+
+/**
+ * Returns an array with the values of each key in an enum
+ * @param obj
+ * @returns
+ * @example
+ * enum Status {
+ *   InProgress = 'IN_PROGRESS',
+ *   Complete = 'COMPLETE',
+ * }
+ * enumKeys(Status) // ['IN_PROGRESS', 'COMPLETE']
+ */
+export function enumValues<O extends object, K extends keyof O = keyof O>(
+  obj: O,
+): K[] {
+  return Object.values(obj) as K[]
+}


### PR DESCRIPTION
This is half of the work required in #10. Creating shipments in the UI will come later.

### Changes

- added a new page to edit existing shipments
- adjusted the `TextInput` and `SelectInput` components so that they could output numbers (GraphQL is very strict about validations)
- added a shipment name formatter

### Screenshots

Rows in this table:

<img width="500" alt="Screen Shot 2021-03-14 at 10 30 20 AM" src="https://user-images.githubusercontent.com/3411183/111077954-72cbc700-84b0-11eb-9b48-1fd72227fbd8.png">

...link to this page:

<img width="250" alt="Screen Shot 2021-03-13 at 6 20 46 PM" src="https://user-images.githubusercontent.com/3411183/111077951-72333080-84b0-11eb-9150-b709717fd857.png">

