### PR TITLE
Factor out common offer and pallet authorization logic

### DIFF
--- a/src/resolvers/offer/offer_authorization.ts
+++ b/src/resolvers/offer/offer_authorization.ts
@@ -3,6 +3,12 @@ import { AuthenticatedContext } from '../../apolloServer'
 import Offer from '../../models/offer'
 import { OfferStatus, ShipmentStatus } from '../../server-internal-types'
 
+/**
+ * Asserts that an offer has a shipment and sending group.
+ * Throws {@link ApolloError} if missing either
+ *
+ * @param {Offer} offer - the offer check consistency of
+ * */
 const assertAssociations = (offer: Offer): void => {
   if (!offer.sendingGroup) {
     throw new ApolloError(`Offer ${offer.id} has no sending group!`)
@@ -13,6 +19,14 @@ const assertAssociations = (offer: Offer): void => {
   }
 }
 
+/**
+ * Asserts that the authenticated user account in {context} is either an admin or
+ * the captain of the offer's sending group. Throws {@link ForbiddenError} if the
+ * caller is not authorized.
+ *
+ * @param {Offer} offer - the offer to authorize access to
+ * @param {AuthenticatedContext} context - the ApolloServer context containing auth data for the caller
+ * */
 const assertAccountIsCaptainOrAdmin = (
   offer: Offer,
   context: AuthenticatedContext,
@@ -25,6 +39,16 @@ const assertAccountIsCaptainOrAdmin = (
   }
 }
 
+/**
+ * Asserts that the authenticated user account in {context} is authorized to mutate the offer.
+ * Admins may mutate as they wish. The captain of the offer's sending group may mutate when
+ * the offer has status Draft and the shipment has status Open. All other users are unauthorized.
+ *
+ * Throws {@link ForbiddenError} if the caller is not authorized. Throws {@link ApolloError} if the offer is missing essential assocations.
+ *
+ * @param {Offer} offer - the offer to authorize access to
+ * @param {AuthenticatedContext} context - the ApolloServer context containing auth data for the caller
+ * */
 export function authorizeOfferMutation(
   offer: Offer,
   context: AuthenticatedContext,
@@ -47,6 +71,15 @@ export function authorizeOfferMutation(
   }
 }
 
+/**
+ * Asserts that the authenticated user account in {context} is authorized to view the offer.
+ * Admins and captains of the offer's sending group may view. All other users are unauthorized.
+ *
+ * Throws {@link ForbiddenError} if the caller is not authorized. Throws {@link ApolloError} if the offer is missing essential assocations.
+ *
+ * @param {Offer} offer - the offer to authorize access to
+ * @param {AuthenticatedContext} context - the ApolloServer context containing auth data for the caller
+ * */
 export function authorizeOfferQuery(
   offer: Offer,
   context: AuthenticatedContext,

--- a/src/resolvers/offer/offer_authorization.ts
+++ b/src/resolvers/offer/offer_authorization.ts
@@ -1,0 +1,56 @@
+import { ApolloError, ForbiddenError } from 'apollo-server-express'
+import { AuthenticatedContext } from '../../apolloServer'
+import Offer from '../../models/offer'
+import { OfferStatus, ShipmentStatus } from '../../server-internal-types'
+
+const assertAssociations = (offer: Offer): void => {
+  if (!offer.sendingGroup) {
+    throw new ApolloError(`Offer ${offer.id} has no sending group!`)
+  }
+
+  if (!offer.shipment) {
+    throw new ApolloError(`Offer ${offer.id} has no shipment!`)
+  }
+}
+
+const assertAccountIsCaptainOrAdmin = (
+  offer: Offer,
+  context: AuthenticatedContext,
+): void => {
+  if (
+    offer.sendingGroup.captainId !== context.auth.userAccount.id &&
+    !context.auth.isAdmin
+  ) {
+    throw new ForbiddenError('Forbidden to access this offer')
+  }
+}
+
+export function authorizeOfferMutation(
+  offer: Offer,
+  context: AuthenticatedContext,
+): void {
+  assertAssociations(offer)
+  assertAccountIsCaptainOrAdmin(offer, context)
+
+  if (!context.auth.isAdmin) {
+    if (offer.status !== OfferStatus.Draft) {
+      throw new ForbiddenError(
+        'Cannot modify pallets for offer not in draft state',
+      )
+    }
+
+    if (offer.shipment.status !== ShipmentStatus.Open) {
+      throw new ForbiddenError(
+        'Cannot modify pallets when the shipment is not open',
+      )
+    }
+  }
+}
+
+export function authorizeOfferQuery(
+  offer: Offer,
+  context: AuthenticatedContext,
+): void {
+  assertAssociations(offer)
+  assertAccountIsCaptainOrAdmin(offer, context)
+}

--- a/src/tests/offers_api.test.ts
+++ b/src/tests/offers_api.test.ts
@@ -1,8 +1,10 @@
-import gql from 'graphql-tag'
 import { ApolloServerTestClient } from 'apollo-server-testing'
+import gql from 'graphql-tag'
+import { fakeUserAuth } from '../authenticateRequest'
 import Group from '../models/group'
 import Offer from '../models/offer'
 import Shipment from '../models/shipment'
+import UserAccount from '../models/user_account'
 import { sequelize } from '../sequelize'
 import {
   GroupType,
@@ -14,8 +16,6 @@ import {
 } from '../server-internal-types'
 import { makeAdminTestServer, makeTestServer } from '../testServer'
 import { createGroup, createShipment } from './helpers'
-import UserAccount from '../models/user_account'
-import { fakeUserAuth } from '../authenticateRequest'
 
 describe('Offers API', () => {
   let captainTestServer: ApolloServerTestClient,
@@ -330,7 +330,7 @@ describe('Offers API', () => {
         },
       })
 
-      expect(res.errors?.[0].message).toEqual('Not permitted to update offer')
+      expect(res.errors?.[0].message).toEqual('Forbidden to access this offer')
     })
   })
 
@@ -489,9 +489,7 @@ describe('Offers API', () => {
         variables: { id: offer.id },
       })
 
-      expect(res.errors?.[0].message).toEqual(
-        'Not permitted to view that offer',
-      )
+      expect(res.errors?.[0].message).toEqual('Forbidden to access this offer')
     })
   })
 })

--- a/src/tests/pallets_api.test.ts
+++ b/src/tests/pallets_api.test.ts
@@ -118,9 +118,7 @@ describe('Pallets API', () => {
         },
       })
 
-      expect(res.errors?.[0].message).toEqual(
-        'Forbidden to modify pallets for this offer',
-      )
+      expect(res.errors?.[0].message).toEqual('Forbidden to access this offer')
     })
 
     it('is forbidden for the captain when the offer is not in draft', async () => {


### PR DESCRIPTION
Introduces two new functions `authorizeOfferMutation(offer: Offer, context: AuthenticatedContext): void` and `authorizeOfferQuery(offer: Offer, context: AuthenticatedContext): void`