### PR TITLE
Remove nested directories in src/resolvers

### DIFF
--- a/src/resolvers/group.ts
+++ b/src/resolvers/group.ts
@@ -1,13 +1,13 @@
 import { ApolloError, ForbiddenError, UserInputError } from 'apollo-server'
 import { has } from 'lodash'
-import Group, { GroupAttributes } from '../../models/group'
-import UserAccount from '../../models/user_account'
+import Group, { GroupAttributes } from '../models/group'
+import UserAccount from '../models/user_account'
 import {
   GroupCreateInput,
   MutationResolvers,
   QueryResolvers,
-} from '../../server-internal-types'
-import stringIsUrl from '../stringIsUrl'
+} from '../server-internal-types'
+import stringIsUrl from './stringIsUrl'
 
 // Group query resolvers
 const listGroups: QueryResolvers['listGroups'] = async () => {

--- a/src/resolvers/line_items.ts
+++ b/src/resolvers/line_items.ts
@@ -1,10 +1,10 @@
 import { ApolloError, UserInputError } from 'apollo-server'
 import { has, isEqual } from 'lodash'
-import { AuthenticatedContext } from '../../apolloServer'
-import Group from '../../models/group'
-import LineItem, { LineItemAttributes } from '../../models/line_item'
-import Offer from '../../models/offer'
-import Pallet from '../../models/pallet'
+import { AuthenticatedContext } from '../apolloServer'
+import Group from '../models/group'
+import LineItem, { LineItemAttributes } from '../models/line_item'
+import Offer from '../models/offer'
+import Pallet from '../models/pallet'
 import {
   DangerousGoods,
   GroupType,
@@ -13,11 +13,11 @@ import {
   LineItemStatus,
   LineItemUpdateInput,
   MutationResolvers,
-} from '../../server-internal-types'
-import getPalletWithParentAssociations from '../getPalletWithParentAssociations'
-import { authorizeOfferMutation } from '../offer/offer_authorization'
-import validateEnumMembership from '../validateEnumMembership'
-import validateUris from '../validateUris'
+} from '../server-internal-types'
+import getPalletWithParentAssociations from './getPalletWithParentAssociations'
+import { authorizeOfferMutation } from './offer_authorization'
+import validateEnumMembership from './validateEnumMembership'
+import validateUris from './validateUris'
 
 const addLineItem: MutationResolvers['addLineItem'] = async (
   _,

--- a/src/resolvers/offer.ts
+++ b/src/resolvers/offer.ts
@@ -1,22 +1,22 @@
 import { ForbiddenError, UserInputError } from 'apollo-server'
 import { has } from 'lodash'
-import Group from '../../models/group'
-import Offer, { OfferAttributes } from '../../models/offer'
-import Pallet from '../../models/pallet'
-import Shipment from '../../models/shipment'
+import Group from '../models/group'
+import Offer, { OfferAttributes } from '../models/offer'
+import Pallet from '../models/pallet'
+import Shipment from '../models/shipment'
 import {
   MutationResolvers,
   OfferResolvers,
   OfferStatus,
   QueryResolvers,
   ShipmentStatus,
-} from '../../server-internal-types'
-import validateEnumMembership from '../validateEnumMembership'
-import validateUris from '../validateUris'
+} from '../server-internal-types'
 import {
   authorizeOfferMutation,
   authorizeOfferQuery,
 } from './offer_authorization'
+import validateEnumMembership from './validateEnumMembership'
+import validateUris from './validateUris'
 
 const addOffer: MutationResolvers['addOffer'] = async (
   _parent,

--- a/src/resolvers/offer_authorization.ts
+++ b/src/resolvers/offer_authorization.ts
@@ -1,7 +1,7 @@
 import { ApolloError, ForbiddenError } from 'apollo-server-express'
-import { AuthenticatedContext } from '../../apolloServer'
-import Offer from '../../models/offer'
-import { OfferStatus, ShipmentStatus } from '../../server-internal-types'
+import { AuthenticatedContext } from '../apolloServer'
+import Offer from '../models/offer'
+import { OfferStatus, ShipmentStatus } from '../server-internal-types'
 
 /**
  * Asserts that an offer has a shipment and sending group.

--- a/src/resolvers/pallet.ts
+++ b/src/resolvers/pallet.ts
@@ -1,16 +1,16 @@
 import { ApolloError, UserInputError } from 'apollo-server'
-import LineItem from '../../models/line_item'
-import Offer from '../../models/offer'
-import Pallet, { PalletAttributes } from '../../models/pallet'
+import LineItem from '../models/line_item'
+import Offer from '../models/offer'
+import Pallet, { PalletAttributes } from '../models/pallet'
 import {
   MutationResolvers,
   PalletResolvers,
   PalletType,
   PaymentStatus,
-} from '../../server-internal-types'
-import getPalletWithParentAssociations from '../getPalletWithParentAssociations'
-import { authorizeOfferMutation } from '../offer/offer_authorization'
-import validateEnumMembership from '../validateEnumMembership'
+} from '../server-internal-types'
+import getPalletWithParentAssociations from './getPalletWithParentAssociations'
+import { authorizeOfferMutation } from './offer_authorization'
+import validateEnumMembership from './validateEnumMembership'
 
 const addPallet: MutationResolvers['addPallet'] = async (
   _,

--- a/src/resolvers/shipment.ts
+++ b/src/resolvers/shipment.ts
@@ -1,6 +1,6 @@
 import { ApolloError, ForbiddenError, UserInputError } from 'apollo-server'
-import Group from '../../models/group'
-import Shipment, { ShipmentAttributes } from '../../models/shipment'
+import Group from '../models/group'
+import Shipment, { ShipmentAttributes } from '../models/shipment'
 import {
   MutationResolvers,
   QueryResolvers,
@@ -8,8 +8,8 @@ import {
   ShipmentResolvers,
   ShipmentStatus,
   ShippingRoute,
-} from '../../server-internal-types'
-import validateEnumMembership from '../validateEnumMembership'
+} from '../server-internal-types'
+import validateEnumMembership from './validateEnumMembership'
 
 // Shipment query resolvers
 const listShipments: QueryResolvers['listShipments'] = async () => {


### PR DESCRIPTION
The resolvers for each resource were in their own subdir of `src/resolvers`. I've found this to be slightly annoying with fuzzy finding and file management since there end up being a bunch of open files with the same basename of `index.ts`. This PR removes the subdirs by making the following moves:

```
src/resolvers/{group/index.ts => group.ts}
src/resolvers/{line_items/index.ts => line_items.ts}
src/resolvers/{offer/index.ts => offer.ts}
src/resolvers/{offer => }/offer_authorization.ts
src/resolvers/{pallet/index.ts => pallet.ts}
src/resolvers/{shipment/index.ts => shipment.ts}
```