### PR TITLE
Add pricing to shipments

### DIFF
--- a/db/migrations/20210323060940-add-pricing-to-shipments.js
+++ b/db/migrations/20210323060940-add-pricing-to-shipments.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Shipments', 'pricing', {
+      type: Sequelize.DataTypes.JSONB,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Shipments', 'pricing')
+  },
+}

--- a/frontend/src/types/api-types.ts
+++ b/frontend/src/types/api-types.ts
@@ -23,6 +23,7 @@ export type Scalars = {
   Int: number
   Float: number
   Date: any
+  Currency: any
 }
 
 export type Location = {
@@ -92,6 +93,7 @@ export type ShipmentUpdateInput = {
   sendingHubId?: Maybe<Scalars['Int']>
   receivingHubId?: Maybe<Scalars['Int']>
   status?: Maybe<ShipmentStatus>
+  pricing?: Maybe<ShipmentPricingInput>
 }
 
 export type Query = {
@@ -201,6 +203,7 @@ export type ShipmentCreateInput = {
   sendingHubId: Scalars['Int']
   receivingHubId: Scalars['Int']
   status: ShipmentStatus
+  pricing?: Maybe<ShipmentPricingInput>
 }
 
 export enum ShippingRoute {
@@ -228,9 +231,32 @@ export type Shipment = {
   sendingHub: Group
   receivingHubId: Scalars['Int']
   receivingHub: Group
+  pricing?: Maybe<ShipmentPricing>
   statusChangeTime: Scalars['Date']
   createdAt: Scalars['Date']
   updatedAt: Scalars['Date']
+}
+
+export type ShipmentPricing = {
+  __typename?: 'ShipmentPricing'
+  singlePallet?: Maybe<MoneyAmount>
+  halfPallet?: Maybe<MoneyAmount>
+}
+
+export type ShipmentPricingInput = {
+  singlePallet?: Maybe<MoneyAmountInput>
+  halfPallet?: Maybe<MoneyAmountInput>
+}
+
+export type MoneyAmount = {
+  __typename?: 'MoneyAmount'
+  currency: Scalars['Currency']
+  quantityInMinorUnits: Scalars['Int']
+}
+
+export type MoneyAmountInput = {
+  currency: Scalars['Currency']
+  quantityInMinorUnits: Scalars['Int']
 }
 
 export enum GroupType {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,5 @@
 scalar Date
+scalar Currency
 
 type Location {
   countryCode: String
@@ -65,6 +66,7 @@ input ShipmentUpdateInput {
   sendingHubId: Int
   receivingHubId: Int
   status: ShipmentStatus
+  pricing: ShipmentPricingInput
 }
 
 type Query {
@@ -104,6 +106,7 @@ input ShipmentCreateInput {
   sendingHubId: Int!
   receivingHubId: Int!
   status: ShipmentStatus!
+  pricing: ShipmentPricingInput
 }
 
 enum ShippingRoute {
@@ -132,11 +135,34 @@ type Shipment {
   sendingHub: Group!
   receivingHubId: Int!
   receivingHub: Group!
+  pricing: ShipmentPricing
 
   # default to created
   statusChangeTime: Date!
   createdAt: Date!
   updatedAt: Date!
+}
+
+type ShipmentPricing {
+  singlePallet: MoneyAmount
+  halfPallet: MoneyAmount
+}
+
+input ShipmentPricingInput {
+  singlePallet: MoneyAmountInput
+  halfPallet: MoneyAmountInput
+}
+
+type MoneyAmount {
+  # Currency is a string holding an ISO-4217 currency code
+  currency: Currency!
+  quantityInMinorUnits: Int!
+}
+
+input MoneyAmountInput {
+  # Currency is a string holding an ISO-4217 currency code
+  currency: Currency!
+  quantityInMinorUnits: Int!
 }
 
 enum GroupType {

--- a/src/models/shipment.ts
+++ b/src/models/shipment.ts
@@ -9,7 +9,11 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript'
 import { Optional } from 'sequelize/types'
-import { ShipmentStatus, ShippingRoute } from '../server-internal-types'
+import {
+  ShipmentPricing,
+  ShipmentStatus,
+  ShippingRoute,
+} from '../server-internal-types'
 import Group from './group'
 
 export interface ShipmentAttributes {
@@ -22,10 +26,11 @@ export interface ShipmentAttributes {
   sendingHubId: number
   receivingHubId: number
   statusChangeTime: Date
+  pricing: ShipmentPricing
 }
 
 export interface ShipmentCreationAttributes
-  extends Optional<ShipmentAttributes, 'id' | 'statusChangeTime'> {}
+  extends Optional<ShipmentAttributes, 'id' | 'statusChangeTime' | 'pricing'> {}
 
 @Table({
   timestamps: true,
@@ -67,6 +72,9 @@ export default class Shipment extends Model<
 
   @Column
   public statusChangeTime!: Date
+
+  @Column(DataType.JSONB)
+  public pricing!: ShipmentPricing
 
   @CreatedAt
   @Column

--- a/src/resolvers/shipment.ts
+++ b/src/resolvers/shipment.ts
@@ -1,4 +1,5 @@
 import { ApolloError, ForbiddenError, UserInputError } from 'apollo-server'
+import { has, isEqual } from 'lodash'
 import Group from '../models/group'
 import Shipment, { ShipmentAttributes } from '../models/shipment'
 import {
@@ -74,6 +75,7 @@ const addShipment: MutationResolvers['addShipment'] = async (
     receivingHubId: input.receivingHubId,
     status: input.status,
     statusChangeTime: new Date(),
+    pricing: input.pricing || undefined,
   })
 }
 
@@ -137,6 +139,10 @@ const updateShipment: MutationResolvers['updateShipment'] = async (
   if (shippingRoute) {
     validateEnumMembership(ShippingRoute, shippingRoute)
     updateAttributes.shippingRoute = shippingRoute
+  }
+
+  if (has(input, 'pricing') && !isEqual(input.pricing, shipment.pricing)) {
+    updateAttributes.pricing = input.pricing || undefined
   }
 
   return shipment.update(updateAttributes)

--- a/src/server-internal-types.ts
+++ b/src/server-internal-types.ts
@@ -30,6 +30,7 @@ export type Scalars = {
   Int: number
   Float: number
   Date: any
+  Currency: any
 }
 
 export type Location = {
@@ -99,6 +100,7 @@ export type ShipmentUpdateInput = {
   sendingHubId?: Maybe<Scalars['Int']>
   receivingHubId?: Maybe<Scalars['Int']>
   status?: Maybe<ShipmentStatus>
+  pricing?: Maybe<ShipmentPricingInput>
 }
 
 export type Query = {
@@ -208,6 +210,7 @@ export type ShipmentCreateInput = {
   sendingHubId: Scalars['Int']
   receivingHubId: Scalars['Int']
   status: ShipmentStatus
+  pricing?: Maybe<ShipmentPricingInput>
 }
 
 export enum ShippingRoute {
@@ -235,9 +238,32 @@ export type Shipment = {
   sendingHub: Group
   receivingHubId: Scalars['Int']
   receivingHub: Group
+  pricing?: Maybe<ShipmentPricing>
   statusChangeTime: Scalars['Date']
   createdAt: Scalars['Date']
   updatedAt: Scalars['Date']
+}
+
+export type ShipmentPricing = {
+  __typename?: 'ShipmentPricing'
+  singlePallet?: Maybe<MoneyAmount>
+  halfPallet?: Maybe<MoneyAmount>
+}
+
+export type ShipmentPricingInput = {
+  singlePallet?: Maybe<MoneyAmountInput>
+  halfPallet?: Maybe<MoneyAmountInput>
+}
+
+export type MoneyAmount = {
+  __typename?: 'MoneyAmount'
+  currency: Scalars['Currency']
+  quantityInMinorUnits: Scalars['Int']
+}
+
+export type MoneyAmountInput = {
+  currency: Scalars['Currency']
+  quantityInMinorUnits: Scalars['Int']
 }
 
 export enum GroupType {
@@ -518,6 +544,7 @@ export type DirectiveResolverFn<
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = ResolversObject<{
   Date: ResolverTypeWrapper<Scalars['Date']>
+  Currency: ResolverTypeWrapper<Scalars['Currency']>
   Location: ResolverTypeWrapper<Location>
   String: ResolverTypeWrapper<Scalars['String']>
   ContactInfo: ResolverTypeWrapper<ContactInfo>
@@ -534,6 +561,10 @@ export type ResolversTypes = ResolversObject<{
   ShippingRoute: ShippingRoute
   ShipmentStatus: ShipmentStatus
   Shipment: ResolverTypeWrapper<Shipment>
+  ShipmentPricing: ResolverTypeWrapper<ShipmentPricing>
+  ShipmentPricingInput: ShipmentPricingInput
+  MoneyAmount: ResolverTypeWrapper<MoneyAmount>
+  MoneyAmountInput: MoneyAmountInput
   GroupType: GroupType
   UserProfile: ResolverTypeWrapper<UserProfile>
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>
@@ -557,6 +588,7 @@ export type ResolversTypes = ResolversObject<{
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = ResolversObject<{
   Date: Scalars['Date']
+  Currency: Scalars['Currency']
   Location: Location
   String: Scalars['String']
   ContactInfo: ContactInfo
@@ -571,6 +603,10 @@ export type ResolversParentTypes = ResolversObject<{
   Mutation: {}
   ShipmentCreateInput: ShipmentCreateInput
   Shipment: Shipment
+  ShipmentPricing: ShipmentPricing
+  ShipmentPricingInput: ShipmentPricingInput
+  MoneyAmount: MoneyAmount
+  MoneyAmountInput: MoneyAmountInput
   UserProfile: UserProfile
   Boolean: Scalars['Boolean']
   Offer: Offer
@@ -586,6 +622,11 @@ export type ResolversParentTypes = ResolversObject<{
 export interface DateScalarConfig
   extends GraphQLScalarTypeConfig<ResolversTypes['Date'], any> {
   name: 'Date'
+}
+
+export interface CurrencyScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['Currency'], any> {
+  name: 'Currency'
 }
 
 export type LocationResolvers<
@@ -784,9 +825,44 @@ export type ShipmentResolvers<
   sendingHub?: Resolver<ResolversTypes['Group'], ParentType, ContextType>
   receivingHubId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
   receivingHub?: Resolver<ResolversTypes['Group'], ParentType, ContextType>
+  pricing?: Resolver<
+    Maybe<ResolversTypes['ShipmentPricing']>,
+    ParentType,
+    ContextType
+  >
   statusChangeTime?: Resolver<ResolversTypes['Date'], ParentType, ContextType>
   createdAt?: Resolver<ResolversTypes['Date'], ParentType, ContextType>
   updatedAt?: Resolver<ResolversTypes['Date'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type ShipmentPricingResolvers<
+  ContextType = AuthenticatedContext,
+  ParentType extends ResolversParentTypes['ShipmentPricing'] = ResolversParentTypes['ShipmentPricing']
+> = ResolversObject<{
+  singlePallet?: Resolver<
+    Maybe<ResolversTypes['MoneyAmount']>,
+    ParentType,
+    ContextType
+  >
+  halfPallet?: Resolver<
+    Maybe<ResolversTypes['MoneyAmount']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type MoneyAmountResolvers<
+  ContextType = AuthenticatedContext,
+  ParentType extends ResolversParentTypes['MoneyAmount'] = ResolversParentTypes['MoneyAmount']
+> = ResolversObject<{
+  currency?: Resolver<ResolversTypes['Currency'], ParentType, ContextType>
+  quantityInMinorUnits?: Resolver<
+    ResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
 
@@ -936,12 +1012,15 @@ export type LineItemResolvers<
 
 export type Resolvers<ContextType = AuthenticatedContext> = ResolversObject<{
   Date?: GraphQLScalarType
+  Currency?: GraphQLScalarType
   Location?: LocationResolvers<ContextType>
   ContactInfo?: ContactInfoResolvers<ContextType>
   Group?: GroupResolvers<ContextType>
   Query?: QueryResolvers<ContextType>
   Mutation?: MutationResolvers<ContextType>
   Shipment?: ShipmentResolvers<ContextType>
+  ShipmentPricing?: ShipmentPricingResolvers<ContextType>
+  MoneyAmount?: MoneyAmountResolvers<ContextType>
   UserProfile?: UserProfileResolvers<ContextType>
   Offer?: OfferResolvers<ContextType>
   Pallet?: PalletResolvers<ContextType>

--- a/src/tests/helpers/index.ts
+++ b/src/tests/helpers/index.ts
@@ -1,11 +1,9 @@
 import { Maybe } from 'graphql/jsutils/Maybe'
 import Group from '../../models/group'
-import Offer from '../../models/offer'
 import Shipment from '../../models/shipment'
 import UserAccount from '../../models/user_account'
 import {
   GroupCreateInput,
-  OfferCreateInput,
   ShipmentCreateInput,
 } from '../../server-internal-types'
 
@@ -26,7 +24,10 @@ async function createGroup(
 }
 
 async function createShipment(input: ShipmentCreateInput): Promise<Shipment> {
-  return await Shipment.create(input)
+  return await Shipment.create({
+    ...input,
+    pricing: input.pricing || undefined,
+  })
 }
 
 export { createGroup, createShipment }

--- a/src/tests/shipments_api.test.ts
+++ b/src/tests/shipments_api.test.ts
@@ -125,6 +125,12 @@ describe('Shipments API', () => {
           id
           status
           statusChangeTime
+          pricing {
+            singlePallet {
+              currency
+              quantityInMinorUnits
+            }
+          }
         }
       }
     `
@@ -239,6 +245,9 @@ describe('Shipments API', () => {
             id: shipment.id,
             input: {
               status: ShipmentStatus.InProgress,
+              pricing: {
+                singlePallet: { currency: 'EUR', quantityInMinorUnits: 100 },
+              },
             },
           },
         })
@@ -249,6 +258,12 @@ describe('Shipments API', () => {
         expect(res.data?.updateShipment?.statusChangeTime).not.toBe(
           shipment.statusChangeTime,
         )
+        expect(
+          res.data?.updateShipment?.pricing?.singlePallet?.currency,
+        ).toEqual('EUR')
+        expect(
+          res.data?.updateShipment?.pricing?.singlePallet?.quantityInMinorUnits,
+        ).toEqual(100)
       })
     })
   })


### PR DESCRIPTION
Also introduces a new type to the schema to represent quantities of money in any currency:
```graphql
type MoneyAmount {
  # Currency is a string holding an ISO-4217 currency code
  currency: Currency!
  quantityInMinorUnits: Int!
}
```