### PR TITLE
Mobile styling improvements, better pallet editor UI

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -41,7 +41,7 @@ const Button: FunctionComponent<ButtonProps> & { Icon: typeof ButtonIcon } = ({
   const { disabled, className, children } = otherProps
 
   const classes = cx(
-    'inline-flex items-center border text-center text-sm leading-5 font-medium rounded whitespace-no-wrap focus:outline-none focus:ring-4 transition ease-in-out duration-100',
+    'inline-flex items-center border justify-center text-sm leading-5 font-medium rounded whitespace-no-wrap focus:outline-none focus:ring-4 transition ease-in-out duration-100',
     className,
     {
       // Default

--- a/frontend/src/components/icons/ChevronIcon.tsx
+++ b/frontend/src/components/icons/ChevronIcon.tsx
@@ -1,0 +1,36 @@
+import cx from 'classnames'
+import { FunctionComponent, SVGProps } from 'react'
+
+interface Props extends SVGProps<SVGSVGElement> {
+  direction?: 'up' | 'right' | 'down' | 'left'
+}
+
+const ChevronIcon: FunctionComponent<Props> = ({
+  direction,
+  className,
+  ...otherProps
+}) => {
+  const classes = cx(className, {
+    'transform rotate-90': direction === 'down',
+    'transform rotate-180': direction === 'left',
+    'transform -rotate-90': direction === 'up',
+  })
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className={classes}
+      {...otherProps}
+    >
+      <path
+        fillRule="evenodd"
+        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+        clipRule="evenodd"
+      />
+    </svg>
+  )
+}
+
+export default ChevronIcon

--- a/frontend/src/components/navigation/MobileNavigation.tsx
+++ b/frontend/src/components/navigation/MobileNavigation.tsx
@@ -50,7 +50,7 @@ const MobileNavigation: FunctionComponent<Props> = ({ navLinks }) => {
           <li key={link.path}>
             <Link
               to={link.path}
-              className="py-2 px-4 flex items-center text-white"
+              className="py-2 px-4 flex items-center text-xl text-white"
             >
               {link.icon}
               {link.label}

--- a/frontend/src/pages/groups/GroupList.tsx
+++ b/frontend/src/pages/groups/GroupList.tsx
@@ -49,13 +49,13 @@ const GroupList: FunctionComponent = () => {
 
   return (
     <LayoutWithNav>
-      <div className="max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content">
+      <div className="max-w-5xl mx-auto bg-white border-l border-r border-gray-200 min-h-content">
         <header className="p-6 border-b border-gray-200 flex items-center justify-between">
           <h1 className="text-navy-800 text-3xl">Groups</h1>
-          <ButtonLink to={ROUTES.GROUP_CREATE}>Create a group</ButtonLink>
+          <ButtonLink to={ROUTES.GROUP_CREATE}>Create group</ButtonLink>
         </header>
-        <main>
-          <table className="w-full" {...getTableProps()}>
+        <main className="overflow-x-auto pb-8">
+          <table className="w-full whitespace-nowrap" {...getTableProps()}>
             <thead className="border-b border-gray-200">
               {headerGroups.map((headerGroup) => (
                 <tr {...headerGroup.getHeaderGroupProps()}>

--- a/frontend/src/pages/offers/PalletsEditor.tsx
+++ b/frontend/src/pages/offers/PalletsEditor.tsx
@@ -1,14 +1,23 @@
 import cx from 'classnames'
 import { FunctionComponent, useState } from 'react'
+import Button from '../../components/Button'
+import ChevronIcon from '../../components/icons/ChevronIcon'
+import useModalState from '../../hooks/useModalState'
 import {
+  OfferDocument,
   OfferQuery,
+  PalletCreateInput,
   PalletDocument,
+  PalletType,
   useCreateLineItemMutation,
+  useCreatePalletMutation,
   usePalletLazyQuery,
 } from '../../types/api-types'
+import CreatePalletModal from './CreatePalletModal'
 import LineItemForm from './LineItemForm'
 interface Props {
-  pallets: OfferQuery['offer']['pallets']
+  offerId: number
+  pallets?: OfferQuery['offer']['pallets']
   initiateDeletePallet: (palletId: number) => void
 }
 
@@ -16,7 +25,7 @@ interface Props {
  * This is a 2-column UI with a list of pallets on the left and details aobut
  * each line-item on the right.
  */
-const PalletsEditor: FunctionComponent<Props> = ({ pallets }) => {
+const PalletsEditor: FunctionComponent<Props> = ({ offerId, pallets = [] }) => {
   // TODO move this to the URL?
   const [selectedPalletId, setSelectedPalletId] = useState<number>()
 
@@ -57,9 +66,57 @@ const PalletsEditor: FunctionComponent<Props> = ({ pallets }) => {
     })
   }
 
+  const [
+    createModalIsVisible,
+    showCreateModal,
+    hideCreateModal,
+  ] = useModalState()
+
+  const [
+    addPallet,
+    { loading: mutationIsLoading, error: mutationError },
+  ] = useCreatePalletMutation({
+    update: (cache, { data }) => {
+      // Manually update the cache with the new pallet
+      try {
+        const offerData = cache.readQuery<OfferQuery>({
+          query: OfferDocument,
+          variables: { id: offerId },
+        })
+
+        cache.writeQuery<OfferQuery>({
+          query: OfferDocument,
+          variables: { id: offerId },
+          data: {
+            offer: Object.assign({}, offerData!.offer, {
+              pallets: [...offerData!.offer.pallets, data!.addPallet],
+            }),
+          },
+        })
+      } catch (error) {
+        console.error(error)
+      }
+    },
+  })
+
+  const onCreatePallet = (palletType: PalletType) => {
+    const newPallet: PalletCreateInput = {
+      palletType,
+      offerId,
+    }
+
+    addPallet({ variables: { input: newPallet } }).then(hideCreateModal)
+  }
+
   return (
-    <section className="flex border border-gray-100">
-      <div className="w-1/3">
+    <>
+      <div className="w-1/3 h-full">
+        <div className="flex items-center justify-between p-4 border-b border-gray-200">
+          <span className="font-semibold text-gray-800">Pallets</span>
+          <Button disabled={mutationIsLoading} onClick={showCreateModal}>
+            Add a pallet
+          </Button>
+        </div>
         <ul className="divide-y divide-gray-100">
           {pallets.map((pallet) => (
             <li
@@ -67,20 +124,37 @@ const PalletsEditor: FunctionComponent<Props> = ({ pallets }) => {
               className="bg-white"
               onClick={() => selectPallet(pallet.id)}
             >
-              <div
-                className={cx('p-4 bg-white border-l-4 border-transparent', {
-                  'border-blue-500': selectedPalletId === pallet.id,
-                })}
-              >
-                <div className="mb-2 font-semibold">Pallet {pallet.id}</div>
+              <div className="bg-white">
+                <div
+                  className={cx(
+                    'p-4 font-semibold flex items-center text-gray-800',
+                    {
+                      'cursor-pointer hover:bg-gray-100':
+                        pallet.id !== selectedPalletId,
+                    },
+                  )}
+                >
+                  <ChevronIcon
+                    className="w-5 h-5 mr-4 text-gray-500"
+                    direction={
+                      pallet.id === selectedPalletId ? 'down' : 'right'
+                    }
+                  />
+                  Pallet {pallet.id}
+                </div>
                 {selectedPalletId === pallet.id && (
-                  <div className="border border-gray-200 flex flex-col mt-2 rounded">
+                  <div className="flex flex-col pb-4 pr-4 pl-8">
                     {selectedPalletData.data?.pallet.lineItems.map((item) => (
                       <button
                         type="button"
-                        className={cx('px-4 py-2 text-left border-l-4', {
-                          'border-blue-500': item.id === selectedLineItemId,
-                        })}
+                        className={cx(
+                          'px-4 py-2 text-left border-l-4 border-transparent',
+                          {
+                            'hover:bg-gray-100': item.id !== selectedLineItemId,
+                            'border-navy-500 bg-navy-100 text-navy-700':
+                              item.id === selectedLineItemId,
+                          },
+                        )}
                         key={item.id}
                         onClick={(e) => {
                           e.stopPropagation()
@@ -90,16 +164,15 @@ const PalletsEditor: FunctionComponent<Props> = ({ pallets }) => {
                         Item {item.id}
                       </button>
                     ))}
-                    <button
-                      type="button"
-                      className="px-4 py-2 text-left border-t"
+                    <Button
+                      className="mt-4"
                       onClick={(e) => {
                         e.stopPropagation()
                         addLineItem(pallet.id)
                       }}
                     >
                       Add a line item
-                    </button>
+                    </Button>
                   </div>
                 )}
               </div>
@@ -108,6 +181,12 @@ const PalletsEditor: FunctionComponent<Props> = ({ pallets }) => {
         </ul>
       </div>
       <div className="flex-grow border-l border-gray-100">
+        {mutationError && (
+          <div className="p-4 m-4 rounded bg-red-50 mb-6 text-red-800">
+            <p className="font-semibold">Error:</p>
+            <p>{mutationError.message}</p>
+          </div>
+        )}
         {selectedPalletId == null && (
           <div className="flex h-full w-full items-center justify-center bg-gray-50 text-gray-500">
             <p>← Select a pallet</p>
@@ -124,7 +203,13 @@ const PalletsEditor: FunctionComponent<Props> = ({ pallets }) => {
           </div>
         )}
       </div>
-    </section>
+      <CreatePalletModal
+        disabled={mutationIsLoading}
+        onCreatePallet={onCreatePallet}
+        isOpen={createModalIsVisible}
+        onRequestClose={hideCreateModal}
+      />
+    </>
   )
 }
 

--- a/frontend/src/pages/offers/ViewOfferPage.tsx
+++ b/frontend/src/pages/offers/ViewOfferPage.tsx
@@ -1,17 +1,11 @@
 import { FunctionComponent, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import Button from '../../components/Button'
 import ReadOnlyField from '../../components/forms/ReadOnlyField'
 import InternalLink from '../../components/InternalLink'
 import ConfirmationModal from '../../components/modal/ConfirmationModal'
 import useModalState from '../../hooks/useModalState'
 import LayoutWithNav from '../../layouts/LayoutWithNav'
 import {
-  OfferDocument,
-  OfferQuery,
-  PalletCreateInput,
-  PalletType,
-  useCreatePalletMutation,
   useDestroyPalletMutation,
   useGroupQuery,
   useOfferQuery,
@@ -19,7 +13,6 @@ import {
 } from '../../types/api-types'
 import { formatShipmentName } from '../../utils/format'
 import { shipmentViewOffersRoute } from '../../utils/routes'
-import CreatePalletModal from './CreatePalletModal'
 import PalletsEditor from './PalletsEditor'
 
 const ViewOfferPage: FunctionComponent = () => {
@@ -38,48 +31,6 @@ const ViewOfferPage: FunctionComponent = () => {
     skip: !sendingGroupId, // Don't execute this query until the group ID is known
     variables: { id: sendingGroupId! },
   })
-
-  const [
-    createModalIsVisible,
-    showCreateModal,
-    hideCreateModal,
-  ] = useModalState()
-
-  const [
-    addPallet,
-    { loading: mutationIsLoading, error: mutationError },
-  ] = useCreatePalletMutation({
-    update: (cache, { data }) => {
-      // Manually update the cache with the new pallet
-      try {
-        const offerData = cache.readQuery<OfferQuery>({
-          query: OfferDocument,
-          variables: { id: offerId },
-        })
-
-        cache.writeQuery<OfferQuery>({
-          query: OfferDocument,
-          variables: { id: offerId },
-          data: {
-            offer: Object.assign({}, offerData!.offer, {
-              pallets: [...offerData!.offer.pallets, data!.addPallet],
-            }),
-          },
-        })
-      } catch (error) {
-        console.error(error)
-      }
-    },
-  })
-
-  const onCreatePallet = (palletType: PalletType) => {
-    const newPallet: PalletCreateInput = {
-      palletType,
-      offerId,
-    }
-
-    addPallet({ variables: { input: newPallet } }).then(hideCreateModal)
-  }
 
   const [
     deleteModalIsVisible,
@@ -113,76 +64,47 @@ const ViewOfferPage: FunctionComponent = () => {
 
   return (
     <LayoutWithNav>
-      <div className="max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content bg-white">
-        <header className="p-6 border-b border-gray-200">
-          <InternalLink
-            className="inline-block mb-2"
-            to={shipmentViewOffersRoute(shipmentId)}
-          >
-            ← back to shipment
-          </InternalLink>
-          <h1 className="text-navy-800 text-3xl">Offer details</h1>
-        </header>
-        <main className="p-4 md:p-6 pb-20 space-y-6">
-          {mutationError && (
-            <div className="p-4 rounded bg-red-50 mb-6 text-red-800">
-              <p className="font-semibold">Error:</p>
-              <p>{mutationError.message}</p>
+      <div className="max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content bg-white flex flex-col">
+        <header className="p-6 border-b border-gray-200 md:flex justify-between">
+          <div>
+            <InternalLink
+              className="inline-block mb-2"
+              to={shipmentViewOffersRoute(shipmentId)}
+            >
+              ← back to shipment
+            </InternalLink>
+            <h1 className="text-navy-800 text-3xl">Offer details</h1>
+          </div>
+          {offer?.offer && (
+            <div className="flex space-x-8 mt-4 md:mt-0">
+              <ReadOnlyField label="Shipment">
+                {shipment?.shipment && (
+                  <>
+                    <p className="text-gray-800">
+                      {formatShipmentName(shipment.shipment)}
+                    </p>
+                    <p className="text-gray-600 text-sm">
+                      {shipment.shipment.sendingHub.name} →{' '}
+                      {shipment.shipment.receivingHub.name}
+                    </p>
+                  </>
+                )}
+              </ReadOnlyField>
+              <ReadOnlyField label="Group">
+                <p className="text-gray-800">{sendingGroup?.group.name}</p>
+                <p className="text-gray-600 text-sm">
+                  {sendingGroup?.group.primaryLocation.townCity}
+                </p>
+              </ReadOnlyField>
             </div>
           )}
-          {offer?.offer && (
-            <>
-              <div className="flex space-x-8">
-                <ReadOnlyField label="Shipment">
-                  {shipment?.shipment && (
-                    <>
-                      <p className="text-gray-800">
-                        {formatShipmentName(shipment.shipment)}
-                      </p>
-                      <p className="text-gray-600 text-sm">
-                        {shipment.shipment.sendingHub.name} →{' '}
-                        {shipment.shipment.receivingHub.name}
-                      </p>
-                    </>
-                  )}
-                </ReadOnlyField>
-                <ReadOnlyField label="Group">
-                  <p className="text-gray-800">{sendingGroup?.group.name}</p>
-                  <p className="text-gray-600 text-sm">
-                    {sendingGroup?.group.primaryLocation.townCity}
-                  </p>
-                </ReadOnlyField>
-              </div>
-              <div className="flex justify-between items-center">
-                <h2 className="text-gray-700 font-semibold">Pallets</h2>
-                {offer.offer.pallets.length > 0 && (
-                  <Button
-                    disabled={mutationIsLoading}
-                    onClick={showCreateModal}
-                  >
-                    Add a pallet
-                  </Button>
-                )}
-              </div>
-              {offer.offer.pallets.length === 0 && (
-                <div className="p-4 flex flex-col space-y-4 items-center justify-center text-gray-500 bg-gray-50 rounded">
-                  <span>There are no pallets in this offer</span>
-                  <Button
-                    disabled={mutationIsLoading}
-                    onClick={showCreateModal}
-                  >
-                    Add a pallet
-                  </Button>
-                </div>
-              )}
-              {offer.offer.pallets.length > 0 && (
-                <PalletsEditor
-                  pallets={offer.offer.pallets}
-                  initiateDeletePallet={selectPalletToDestroy}
-                />
-              )}
-            </>
-          )}
+        </header>
+        <main className="flex-grow flex items-stretch">
+          <PalletsEditor
+            offerId={offerId}
+            pallets={offer?.offer.pallets}
+            initiateDeletePallet={selectPalletToDestroy}
+          />
           <ConfirmationModal
             isOpen={deleteModalIsVisible}
             onCancel={hideDeleteModal}
@@ -193,12 +115,6 @@ const ViewOfferPage: FunctionComponent = () => {
             Are you sure you want to delete this pallet? This action is
             irreversible.
           </ConfirmationModal>
-          <CreatePalletModal
-            disabled={mutationIsLoading}
-            onCreatePallet={onCreatePallet}
-            isOpen={createModalIsVisible}
-            onRequestClose={hideCreateModal}
-          />
         </main>
       </div>
     </LayoutWithNav>

--- a/frontend/src/pages/shipments/ShipmentList.tsx
+++ b/frontend/src/pages/shipments/ShipmentList.tsx
@@ -61,13 +61,13 @@ const ShipmentList: FunctionComponent = () => {
 
   return (
     <LayoutWithNav>
-      <div className="max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content">
-        <header className="p-6 border-b border-gray-200 flex items-center justify-between">
-          <h1 className="text-navy-800 text-3xl">Shipments</h1>
-          <ButtonLink to={ROUTES.SHIPMENT_CREATE}>Create a shipment</ButtonLink>
+      <div className="max-w-5xl mx-auto bg-white border-l border-r border-gray-200 min-h-content">
+        <header className="p-6 border-b border-gray-200 md:flex items-center justify-between">
+          <h1 className="text-navy-800 text-3xl mb-4 md:mb-0">Shipments</h1>
+          <ButtonLink to={ROUTES.SHIPMENT_CREATE}>Create shipment</ButtonLink>
         </header>
-        <main>
-          <table className="w-full" {...getTableProps()}>
+        <main className="pb-20 overflow-x-auto">
+          <table className="w-full whitespace-nowrap" {...getTableProps()}>
             <thead className="border-b border-gray-200">
               {headerGroups.map((headerGroup) => (
                 <tr {...headerGroup.getHeaderGroupProps()}>

--- a/frontend/src/pages/shipments/ShipmentOffers.tsx
+++ b/frontend/src/pages/shipments/ShipmentOffers.tsx
@@ -79,55 +79,55 @@ const ShipmentOffers: FunctionComponent<Props> = ({ shipmentId }) => {
 
   return (
     <div>
-      <div className="p-4 md:p-6 md:flex items-center justify-between">
-        <h2 className="text-lg text-gray-600">Offers for this shipment</h2>
-        <ButtonLink to={offerCreateRoute(shipmentId)}>
-          Create an offer
-        </ButtonLink>
+      <div className="p-4 md:p-6 flex items-center justify-between">
+        <h2 className="text-lg text-gray-700">Offers</h2>
+        <ButtonLink to={offerCreateRoute(shipmentId)}>Create offer</ButtonLink>
       </div>
-      <table className="w-full" {...getTableProps()}>
-        <thead className="border-b border-gray-200">
-          {headerGroups.map((headerGroup) => (
-            <tr {...headerGroup.getHeaderGroupProps()}>
-              {headerGroup.headers.map((column) => (
-                <TableHeader
-                  canSort={column.canSort}
-                  isSorted={column.isSorted}
-                  isSortedDesc={column.isSortedDesc}
-                  title={column.canSort ? 'Sort rows' : ''}
-                  {...column.getHeaderProps(column.getSortByToggleProps())}
-                >
-                  {column.render('Header')}
-                </TableHeader>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody {...getTableBodyProps()}>
-          {rows.map((row) => {
-            prepareRow(row)
-            return (
-              <tr
-                {...row.getRowProps()}
-                className="border-b border-gray-200 px-4"
-              >
-                {row.cells.map((cell) => (
-                  <td
-                    {...cell.getCellProps()}
-                    className={cx('p-2 first:pl-6 last:pr-6', {
-                      'font-semibold text-navy-700 hover:underline':
-                        cell.column.Header === 'Name',
-                      'bg-gray-50': cell.column.isSorted,
-                    })}
+      <div className="overflow-x-auto pb-8">
+        <table className="w-full whitespace-nowrap" {...getTableProps()}>
+          <thead className="border-b border-gray-200">
+            {headerGroups.map((headerGroup) => (
+              <tr {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((column) => (
+                  <TableHeader
+                    canSort={column.canSort}
+                    isSorted={column.isSorted}
+                    isSortedDesc={column.isSortedDesc}
+                    title={column.canSort ? 'Sort rows' : ''}
+                    {...column.getHeaderProps(column.getSortByToggleProps())}
                   >
-                    {cell.render('Cell')}
-                  </td>
+                    {column.render('Header')}
+                  </TableHeader>
                 ))}
               </tr>
-            )
-          })}
-        </tbody>
-      </table>
+            ))}
+          </thead>
+          <tbody {...getTableBodyProps()}>
+            {rows.map((row) => {
+              prepareRow(row)
+              return (
+                <tr
+                  {...row.getRowProps()}
+                  className="border-b border-gray-200 px-4"
+                >
+                  {row.cells.map((cell) => (
+                    <td
+                      {...cell.getCellProps()}
+                      className={cx('p-2 first:pl-6 last:pr-6', {
+                        'font-semibold text-navy-700 hover:underline':
+                          cell.column.Header === 'Name',
+                        'bg-gray-50': cell.column.isSorted,
+                      })}
+                    >
+                      {cell.render('Cell')}
+                    </td>
+                  ))}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
       {rows.length === 0 && (
         <div className="flex items-center justify-center py-8 text-gray-500">
           No offers yet


### PR DESCRIPTION
### Changes

- improvements to styling on mobile, particularly around tables
- cleaned up the UI of the line item editor
- moved the pallet creation code around, but it still works the same

### Pixels

Tables were squished on mobile, but now they're fairly usable:

https://user-images.githubusercontent.com/3411183/113240293-4b6f4b00-9261-11eb-8587-780cfc720d32.mov

I also cleaned up the pallet editor a little:

https://user-images.githubusercontent.com/3411183/113240447-9721f480-9261-11eb-97b2-06edb6af8682.mov



