### PR TITLE
Select and display line item category in the UI

### DIFF
--- a/frontend/src/data/constants.ts
+++ b/frontend/src/data/constants.ts
@@ -1,6 +1,7 @@
 import {
   DangerousGoods,
   GroupType,
+  LineItemCategory,
   LineItemContainerType,
   OfferStatus,
   PalletType,
@@ -60,6 +61,43 @@ export const PALLET_PAYMENT_STATUS_OPTIONS = [
     label: "Won't pay",
     value: PaymentStatus.WontPay,
   },
+]
+
+export const LINE_ITEM_CATEGORY_OPTIONS = [
+  { label: 'Not set', value: LineItemCategory.Unset },
+  {
+    label: "Clothing (men's, women's, children's, babies, shoes)",
+    value: LineItemCategory.Clothing,
+  },
+  {
+    label: 'Shelter & Bedding (tents, sleeping bags, roll mats, blankets)',
+    value: LineItemCategory.Shelter,
+  },
+  {
+    label:
+      'Hygiene & Toiletries (toothbrush, deodorant, shampoo, diapers, soap, etc.)',
+    value: LineItemCategory.Hygiene,
+  },
+  {
+    label:
+      'Food & Drink (canned food, dried food, cooking oil, bottled water, etc.)',
+    value: LineItemCategory.Food,
+  },
+  {
+    label:
+      'Games & Toys (board games, card games, musical instruments, baby toys)',
+    value: LineItemCategory.Games,
+  },
+  {
+    label: 'Electronics (phones, batteries, cables, laptops)',
+    value: LineItemCategory.Electronics,
+  },
+  {
+    label: 'Medical (bandages, plasters, first aid supplies)',
+    value: LineItemCategory.Medical,
+  },
+  { label: 'PPE (masks, antibacterial hand gel)', value: LineItemCategory.Ppe },
+  { label: 'Other (washing machines)', value: LineItemCategory.Other },
 ]
 
 export const LINE_ITEM_CONTAINER_OPTIONS = [

--- a/frontend/src/pages/offers/LineItemForm.tsx
+++ b/frontend/src/pages/offers/LineItemForm.tsx
@@ -7,10 +7,13 @@ import TextField from '../../components/forms/TextField'
 import Spinner from '../../components/Spinner'
 import {
   DANGEROUS_GOODS_LIST,
+  LINE_ITEM_CATEGORY_OPTIONS,
   LINE_ITEM_CONTAINER_OPTIONS,
 } from '../../data/constants'
 import {
   DangerousGoods,
+  LineItemCategory,
+  LineItemContainerType,
   LineItemUpdateInput,
   useLineItemQuery,
   useUpdateLineItemMutation,
@@ -147,6 +150,14 @@ const LineItemForm: FunctionComponent<Props> = ({
             options={LINE_ITEM_CONTAINER_OPTIONS}
             register={register}
             required
+            registerOptions={{
+              validate: {
+                notUnset: (value: LineItemContainerType) =>
+                  value !== LineItemContainerType.Unset ||
+                  'Please select a container type',
+              },
+            }}
+            errors={errors}
           />
           <TextField
             label="Amount of items"
@@ -158,8 +169,20 @@ const LineItemForm: FunctionComponent<Props> = ({
             errors={errors}
           />
         </div>
-        {/* TODO add a category dropdown after we create some enums */}
-        {/* <SelectField label="Category" name="category" options={[]} /> */}
+        <SelectField
+          label="Category"
+          name="category"
+          options={LINE_ITEM_CATEGORY_OPTIONS}
+          register={register}
+          registerOptions={{
+            validate: {
+              notUnset: (value: LineItemCategory) =>
+                value !== LineItemCategory.Unset || 'Please select a category',
+            },
+          }}
+          required
+          errors={errors}
+        />
       </fieldset>
       <fieldset className="space-y-4 mt-12">
         <legend className="font-semibold text-gray-700 ">

--- a/frontend/src/pages/offers/ViewLineItem.tsx
+++ b/frontend/src/pages/offers/ViewLineItem.tsx
@@ -10,6 +10,7 @@ import {
   useDestroyLineItemMutation,
   useLineItemQuery,
 } from '../../types/api-types'
+import { formatLineItemCategory } from '../../utils/format'
 
 interface Props {
   /**
@@ -124,9 +125,10 @@ const ViewLineItem: FunctionComponent<Props> = ({
               <ReadOnlyField label="Number of items">
                 {data.lineItem.itemCount || 0}
               </ReadOnlyField>
+              <ReadOnlyField label="Category">
+                {formatLineItemCategory(data.lineItem.category)}
+              </ReadOnlyField>
             </div>
-            {/* TODO add a category dropdown after we create some enums */}
-            {/* <SelectField label="Category" name="category" options={[]} /> */}
           </fieldset>
           <fieldset className="space-y-4 mt-12">
             <legend className="font-semibold text-gray-700 ">

--- a/frontend/src/pages/offers/ViewLineItem.tsx
+++ b/frontend/src/pages/offers/ViewLineItem.tsx
@@ -125,10 +125,10 @@ const ViewLineItem: FunctionComponent<Props> = ({
               <ReadOnlyField label="Number of items">
                 {data.lineItem.itemCount || 0}
               </ReadOnlyField>
-              <ReadOnlyField label="Category">
-                {formatLineItemCategory(data.lineItem.category)}
-              </ReadOnlyField>
             </div>
+            <ReadOnlyField label="Category">
+              {formatLineItemCategory(data.lineItem.category)}
+            </ReadOnlyField>
           </fieldset>
           <fieldset className="space-y-4 mt-12">
             <legend className="font-semibold text-gray-700 ">

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,7 +1,12 @@
 import { BadgeColor } from '../components/Badge'
-import { COUNTRY_CODES_TO_NAME, MONTHS } from '../data/constants'
+import {
+  COUNTRY_CODES_TO_NAME,
+  LINE_ITEM_CATEGORY_OPTIONS,
+  MONTHS,
+} from '../data/constants'
 import {
   GroupType,
+  LineItemCategory,
   Maybe,
   PalletType,
   Shipment,
@@ -39,6 +44,13 @@ export function formatCountryCodeToName(countryCode?: Maybe<string>) {
   }
 
   return 'Unknown Country'
+}
+
+export function formatLineItemCategory(category: LineItemCategory) {
+  const matchingCategory = LINE_ITEM_CATEGORY_OPTIONS.find(
+    (c) => c.value === category,
+  )
+  return matchingCategory?.label || category
 }
 
 export function formatPalletType(palletType: PalletType) {

--- a/schema.graphql
+++ b/schema.graphql
@@ -268,6 +268,15 @@ enum LineItemStatus {
 
 enum LineItemCategory {
   UNSET
+  CLOTHING
+  SHELTER
+  HYGIENE
+  FOOD
+  GAMES
+  ELECTRONICS
+  MEDICAL
+  PPE
+  OTHER
 }
 
 enum DangerousGoods {

--- a/src/resolvers/line_items.ts
+++ b/src/resolvers/line_items.ts
@@ -121,6 +121,11 @@ async function getUpdateAttributes(
     updateAttributes.containerType = input.containerType
   }
 
+  if (input.category && input.category != lineItem.category) {
+    validateEnumMembership(LineItemCategory, input.category)
+    updateAttributes.category = input.category
+  }
+
   if (
     input.dangerousGoods &&
     !isEqual(input.dangerousGoods, lineItem.dangerousGoods)

--- a/src/tests/line_items_api.test.ts
+++ b/src/tests/line_items_api.test.ts
@@ -253,6 +253,7 @@ describe('LineItems API', () => {
             id: lineItem.id,
             input: {
               status: LineItemStatus.Accepted,
+              category: LineItemCategory.Electronics,
             },
           },
         })
@@ -260,6 +261,9 @@ describe('LineItems API', () => {
         expect(res.errors).toBeUndefined()
         expect(res.data?.updateLineItem?.status).toEqual(
           LineItemStatus.Accepted,
+        )
+        expect(res.data?.updateLineItem?.category).toEqual(
+          LineItemCategory.Electronics,
         )
       })
     })


### PR DESCRIPTION
### Changes

- added categories for line items
- allowed users to select a category for each line item
- persist the line item category in the `updateLineItem` endpoint

### Pixels

<img width="685" alt="Screen Shot 2021-04-07 at 3 40 07 PM" src="https://user-images.githubusercontent.com/3411183/113943475-a18b4380-97b7-11eb-992f-fa203041ada8.png">
<img width="693" alt="Screen Shot 2021-04-07 at 3 40 00 PM" src="https://user-images.githubusercontent.com/3411183/113943477-a223da00-97b7-11eb-8a8b-0509ec2a7373.png">
<img width="674" alt="Screen Shot 2021-04-07 at 3 55 01 PM" src="https://user-images.githubusercontent.com/3411183/113944590-a2bd7000-97b9-11eb-9887-2ac0ca72a0a1.png">

