### PR TITLE
Export shipment to CSV button

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -2,7 +2,10 @@
 REACT_APP_VERSION=$npm_package_version
 
 # The URL where the server runs
-REACT_APP_SERVER_URL="http://localhost:3000/graphql"
+REACT_APP_SERVER_URL="http://localhost:3000"
+
+# The URL where the Apollo server runs
+REACT_APP_GRAPHQL_URL="http://localhost:3000/graphql"
 
 # The URL where the client runs
 REACT_APP_CLIENT_URL="http://localhost:8080"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@types/react-router-dom": "^5.1.7",
     "@types/react-table": "^7.0.28",
     "classnames": "^2.2.6",
+    "date-fns": "^2.20.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hook-form": "^7.0.0",

--- a/frontend/src/components/ApolloAuthProvider.tsx
+++ b/frontend/src/components/ApolloAuthProvider.tsx
@@ -14,7 +14,7 @@ const clientUrl = process.env.REACT_APP_CLIENT_URL
 
 // https://www.apollographql.com/docs/link/links/http/
 const httpLink = new HttpLink({
-  uri: process.env.REACT_APP_SERVER_URL,
+  uri: process.env.REACT_APP_GRAPHQL_URL,
   credentials: 'include',
 })
 

--- a/frontend/src/pages/shipments/DownloadCSVMenu.tsx
+++ b/frontend/src/pages/shipments/DownloadCSVMenu.tsx
@@ -1,0 +1,106 @@
+import { useAuth0 } from '@auth0/auth0-react'
+import format from 'date-fns/format'
+import { FunctionComponent } from 'react'
+import Button from '../../components/Button'
+import PlainModal from '../../components/modal/PlainModal'
+import useModalState from '../../hooks/useModalState'
+import {
+  ShipmentQuery,
+  useExportShipmentToCsvMutation,
+} from '../../types/api-types'
+import { formatShipmentName } from '../../utils/format'
+
+interface Props {
+  shipment: ShipmentQuery['shipment']
+}
+
+const DownloadCSVMenu: FunctionComponent<Props> = ({ shipment }) => {
+  const { getAccessTokenSilently } = useAuth0()
+  const [modalIsVisible, showModal, hideModal] = useModalState()
+
+  const [
+    exportShipment,
+    { loading: exportIsProcessing },
+  ] = useExportShipmentToCsvMutation()
+
+  const exportToCSV = async () => {
+    const shipmentExport = await exportShipment({
+      variables: { shipmentId: shipment.id },
+    })
+    const downloadPath = shipmentExport.data?.exportShipment.downloadPath
+
+    if (!downloadPath) {
+      throw new Error("Unable to download the shipment's data")
+    }
+
+    await downloadShipment(downloadPath)
+  }
+
+  const downloadShipment = async (downloadPath: string) => {
+    const accessToken = await getAccessTokenSilently()
+
+    const spreadsheet = await fetch(downloadPath, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }).then((res) => res.text())
+
+    // Download the CSV file by creating a link and clicking it. Yay HTML
+    const anchorElement = document.createElement('a')
+    const fileName = `${formatShipmentName(shipment)}.csv`
+
+    if (URL && 'download' in anchorElement) {
+      anchorElement.href = URL.createObjectURL(
+        new Blob([spreadsheet], {
+          type: 'application/octet-stream',
+        }),
+      )
+      anchorElement.setAttribute('download', fileName)
+      document.body.appendChild(anchorElement)
+      anchorElement.click()
+      document.body.removeChild(anchorElement)
+    } else {
+      window.location.href =
+        'data:application/octet-stream,' + encodeURIComponent(spreadsheet)
+    }
+  }
+
+  if (!shipment.exports || shipment.exports.length === 0) {
+    return <Button disabled={exportIsProcessing}>Export to CSV</Button>
+  }
+
+  return (
+    <>
+      <Button onClick={exportToCSV}>Export new CSV</Button>
+      <Button onClick={showModal}>Download existing CSV</Button>
+      <PlainModal isOpen={modalIsVisible} onRequestClose={hideModal}>
+        <div className="p-4 pb-0">
+          <h2 className="text-gray-700 text-lg mb-2">Previous versions</h2>
+          <p className="text-gray-800">
+            You can download versions of this shipment that were exported in the
+            past.
+          </p>
+        </div>
+        <div className="max-h-80 overflow-y-auto p-4">
+          <div className="divide-y divide-gray-100 pb-2">
+            {shipment.exports.map((e) => (
+              <div
+                key={e.id}
+                className="py-2 flex items-center justify-between"
+              >
+                <span>{format(new Date(e.createdAt), 'MMM do, yyyy')}</span>
+                <Button
+                  slim
+                  disabled={exportIsProcessing}
+                  onClick={() => downloadShipment(e.downloadPath)}
+                >
+                  Export
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </PlainModal>
+    </>
+  )
+}
+
+export default DownloadCSVMenu

--- a/frontend/src/pages/shipments/DownloadCSVMenu.tsx
+++ b/frontend/src/pages/shipments/DownloadCSVMenu.tsx
@@ -63,23 +63,27 @@ const DownloadCSVMenu: FunctionComponent<Props> = ({ shipment }) => {
     }
   }
 
-  const sortedExports = useMemo(() => {
-    if (shipment.exports) {
-      const sorted = [...shipment.exports]
-      sorted.sort((a, b) => {
-        const aValue = new Date(a.createdAt)
-        const bValue = new Date(b.createdAt)
-        if (aValue > bValue) {
-          return -1
-        } else if (aValue < bValue) {
-          return 1
-        }
-        return 0
-      })
-      return sorted
-    }
-    return []
-  }, [shipment.exports])
+  const sortedExports = useMemo(
+    function sortExportsChronologically() {
+      if (shipment.exports) {
+        const sorted = [...shipment.exports]
+        sorted.sort((a, b) => {
+          const aValue = new Date(a.createdAt)
+          const bValue = new Date(b.createdAt)
+          if (aValue > bValue) {
+            return -1
+          } else if (aValue < bValue) {
+            return 1
+          }
+          return 0
+        })
+        return sorted
+      }
+
+      return []
+    },
+    [shipment.exports],
+  )
 
   if (!shipment.exports || shipment.exports.length === 0) {
     return <Button disabled={exportIsProcessing}>Export to CSV</Button>

--- a/frontend/src/pages/shipments/DownloadCSVMenu.tsx
+++ b/frontend/src/pages/shipments/DownloadCSVMenu.tsx
@@ -1,6 +1,6 @@
 import { useAuth0 } from '@auth0/auth0-react'
 import format from 'date-fns/format'
-import { FunctionComponent } from 'react'
+import { FunctionComponent, useMemo } from 'react'
 import Button from '../../components/Button'
 import PlainModal from '../../components/modal/PlainModal'
 import useModalState from '../../hooks/useModalState'
@@ -63,6 +63,24 @@ const DownloadCSVMenu: FunctionComponent<Props> = ({ shipment }) => {
     }
   }
 
+  const sortedExports = useMemo(() => {
+    if (shipment.exports) {
+      const sorted = [...shipment.exports]
+      sorted.sort((a, b) => {
+        const aValue = new Date(a.createdAt)
+        const bValue = new Date(b.createdAt)
+        if (aValue > bValue) {
+          return -1
+        } else if (aValue < bValue) {
+          return 1
+        }
+        return 0
+      })
+      return sorted
+    }
+    return []
+  }, [shipment.exports])
+
   if (!shipment.exports || shipment.exports.length === 0) {
     return <Button disabled={exportIsProcessing}>Export to CSV</Button>
   }
@@ -81,12 +99,14 @@ const DownloadCSVMenu: FunctionComponent<Props> = ({ shipment }) => {
         </div>
         <div className="max-h-80 overflow-y-auto p-4">
           <div className="divide-y divide-gray-100 pb-2">
-            {shipment.exports.map((e) => (
+            {sortedExports.map((e) => (
               <div
                 key={e.id}
                 className="py-2 flex items-center justify-between"
               >
-                <span>{format(new Date(e.createdAt), 'MMM do, yyyy')}</span>
+                <span>
+                  {format(new Date(e.createdAt), 'MMM d, yyyy, H:mm')}
+                </span>
                 <Button
                   slim
                   disabled={exportIsProcessing}

--- a/frontend/src/pages/shipments/DownloadCSVMenu.tsx
+++ b/frontend/src/pages/shipments/DownloadCSVMenu.tsx
@@ -8,11 +8,12 @@ import {
   ShipmentQuery,
   useExportShipmentToCsvMutation,
 } from '../../types/api-types'
-import { formatShipmentName } from '../../utils/format'
 
 interface Props {
   shipment: ShipmentQuery['shipment']
 }
+
+const SERVER_URL = process.env.REACT_APP_SERVER_URL
 
 const DownloadCSVMenu: FunctionComponent<Props> = ({ shipment }) => {
   const { getAccessTokenSilently } = useAuth0()
@@ -39,28 +40,9 @@ const DownloadCSVMenu: FunctionComponent<Props> = ({ shipment }) => {
   const downloadShipment = async (downloadPath: string) => {
     const accessToken = await getAccessTokenSilently()
 
-    const spreadsheet = await fetch(downloadPath, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    }).then((res) => res.text())
-
-    // Download the CSV file by creating a link and clicking it. Yay HTML
-    const anchorElement = document.createElement('a')
-    const fileName = `${formatShipmentName(shipment)}.csv`
-
-    if (URL && 'download' in anchorElement) {
-      anchorElement.href = URL.createObjectURL(
-        new Blob([spreadsheet], {
-          type: 'application/octet-stream',
-        }),
-      )
-      anchorElement.setAttribute('download', fileName)
-      document.body.appendChild(anchorElement)
-      anchorElement.click()
-      document.body.removeChild(anchorElement)
-    } else {
-      window.location.href =
-        'data:application/octet-stream,' + encodeURIComponent(spreadsheet)
-    }
+    const downloadUrl = new URL(downloadPath, SERVER_URL)
+    downloadUrl.searchParams.append('authorization', `Bearer ${accessToken}`)
+    window.open(downloadUrl.href)
   }
 
   const sortedExports = useMemo(

--- a/frontend/src/pages/shipments/ShipmentViewPage.tsx
+++ b/frontend/src/pages/shipments/ShipmentViewPage.tsx
@@ -1,7 +1,6 @@
 import { useAuth0 } from '@auth0/auth0-react'
 import { FunctionComponent, useContext } from 'react'
 import { Route, Switch, useParams } from 'react-router-dom'
-import Button from '../../components/Button'
 import ButtonLink from '../../components/ButtonLink'
 import InternalLink from '../../components/InternalLink'
 import TabLink from '../../components/tabs/TabLink'
@@ -18,6 +17,7 @@ import ROUTES, {
   shipmentViewOffersRoute,
   shipmentViewRoute,
 } from '../../utils/routes'
+import DownloadCSVMenu from './DownloadCSVMenu'
 import ShipmentDetails from './ShipmentDetails'
 import ShipmentOffers from './ShipmentOffers'
 
@@ -93,14 +93,13 @@ const ShipmentViewPage: FunctionComponent = () => {
             </h1>
           </div>
           <div className="flex-shrink space-x-4 mt-4 md:mt-0">
-            {user?.isAdmin && (
-              <Button disabled={exportIsProcessing} onClick={exportToCSV}>
-                Export to CSV
-              </Button>
+            {user?.isAdmin && shipment && (
+              <DownloadCSVMenu shipment={shipment.shipment} />
             )}
             <ButtonLink to={shipmentEditRoute(shipmentId)}>Edit</ButtonLink>
           </div>
         </header>
+
         <TabList>
           <TabLink to={shipmentViewRoute(shipmentId)}>Details</TabLink>
           <TabLink to={shipmentViewOffersRoute(shipmentId)}>Offers</TabLink>

--- a/frontend/src/pages/shipments/ShipmentViewPage.tsx
+++ b/frontend/src/pages/shipments/ShipmentViewPage.tsx
@@ -1,4 +1,3 @@
-import { useAuth0 } from '@auth0/auth0-react'
 import { FunctionComponent, useContext } from 'react'
 import { Route, Switch, useParams } from 'react-router-dom'
 import ButtonLink from '../../components/ButtonLink'
@@ -7,10 +6,7 @@ import TabLink from '../../components/tabs/TabLink'
 import TabList from '../../components/tabs/TabList'
 import { UserProfileContext } from '../../components/UserProfileContext'
 import LayoutWithNav from '../../layouts/LayoutWithNav'
-import {
-  useExportShipmentToCsvMutation,
-  useShipmentQuery,
-} from '../../types/api-types'
+import { useShipmentQuery } from '../../types/api-types'
 import { formatShipmentName } from '../../utils/format'
 import ROUTES, {
   shipmentEditRoute,
@@ -22,8 +18,6 @@ import ShipmentDetails from './ShipmentDetails'
 import ShipmentOffers from './ShipmentOffers'
 
 const ShipmentViewPage: FunctionComponent = () => {
-  const { getAccessTokenSilently } = useAuth0()
-
   const user = useContext(UserProfileContext)
   const params = useParams<{ shipmentId: string }>()
   const shipmentId = parseInt(params.shipmentId, 10)
@@ -33,49 +27,6 @@ const ShipmentViewPage: FunctionComponent = () => {
   })
 
   const shipmentData = shipment?.shipment
-
-  const [
-    exportShipment,
-    { loading: exportIsProcessing },
-  ] = useExportShipmentToCsvMutation()
-
-  const exportToCSV = async () => {
-    if (!shipment) {
-      return
-    }
-
-    const shipmentExport = await exportShipment({ variables: { shipmentId } })
-    const downloadPath = shipmentExport.data?.exportShipment.downloadPath
-
-    if (!downloadPath) {
-      throw new Error("Unable to download the shipment's data")
-    }
-
-    const accessToken = await getAccessTokenSilently()
-
-    const spreadsheet = await fetch(downloadPath, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    }).then((res) => res.text())
-
-    // Download the CSV file by creating a link and clicking it. Yay HTML
-    const anchorElement = document.createElement('a')
-    const fileName = `${formatShipmentName(shipment.shipment)}.csv`
-
-    if (URL && 'download' in anchorElement) {
-      anchorElement.href = URL.createObjectURL(
-        new Blob([spreadsheet], {
-          type: 'application/octet-stream',
-        }),
-      )
-      anchorElement.setAttribute('download', fileName)
-      document.body.appendChild(anchorElement)
-      anchorElement.click()
-      document.body.removeChild(anchorElement)
-    } else {
-      window.location.href =
-        'data:application/octet-stream,' + encodeURIComponent(spreadsheet)
-    }
-  }
 
   return (
     <LayoutWithNav>

--- a/frontend/src/pages/shipments/ShipmentViewPage.tsx
+++ b/frontend/src/pages/shipments/ShipmentViewPage.tsx
@@ -40,6 +40,10 @@ const ShipmentViewPage: FunctionComponent = () => {
   ] = useExportShipmentToCsvMutation()
 
   const exportToCSV = async () => {
+    if (!shipment) {
+      return
+    }
+
     const shipmentExport = await exportShipment({ variables: { shipmentId } })
     const downloadPath = shipmentExport.data?.exportShipment.downloadPath
 
@@ -55,7 +59,7 @@ const ShipmentViewPage: FunctionComponent = () => {
 
     // Download the CSV file by creating a link and clicking it. Yay HTML
     const anchorElement = document.createElement('a')
-    const fileName = `shipment-${shipmentId}.csv`
+    const fileName = `${formatShipmentName(shipment.shipment)}.csv`
 
     if (URL && 'download' in anchorElement) {
       anchorElement.href = URL.createObjectURL(

--- a/frontend/src/pages/shipments/getShipmentQuery.graphql
+++ b/frontend/src/pages/shipments/getShipmentQuery.graphql
@@ -1,5 +1,13 @@
 query Shipment($id: Int!) {
   shipment(id: $id) {
     ...AllShipmentFields
+    exports {
+      id
+      downloadPath
+      createdBy {
+        id
+      }
+      createdAt
+    }
   }
 }

--- a/frontend/src/pages/shipments/shipmentExports.graphql
+++ b/frontend/src/pages/shipments/shipmentExports.graphql
@@ -1,0 +1,6 @@
+mutation ExportShipmentToCSV($shipmentId: Int!) {
+  exportShipment(shipmentId: $shipmentId) {
+    id
+    downloadPath
+  }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4008,6 +4008,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.20.1.tgz#7e60b7035284a5f83e37500376e738d9f49ecfd3"
+  integrity sha512-8P5M8Kxbnovd0zfvOs7ipkiVJ3/zZQ0F/nrBW4x5E+I0uAZVZ80h6CKd24fSXQ5TLK5hXMtI4yb2O5rEZdUt2A==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,5 @@
 scalar Date
+scalar DateTime
 scalar Currency
 
 type Location {
@@ -38,8 +39,8 @@ type Group {
   website: String
   captainId: Int!
 
-  createdAt: Date!
-  updatedAt: Date!
+  createdAt: DateTime!
+  updatedAt: DateTime!
 }
 
 input GroupCreateInput {
@@ -150,9 +151,9 @@ type Shipment {
   exports: [ShipmentExport!]
 
   # default to created
-  statusChangeTime: Date!
-  createdAt: Date!
-  updatedAt: Date!
+  statusChangeTime: DateTime!
+  createdAt: DateTime!
+  updatedAt: DateTime!
 }
 
 type ShipmentPricing {
@@ -208,9 +209,9 @@ type Offer {
   photoUris: [String!]!
   pallets: [Pallet!]!
 
-  statusChangeTime: Date!
-  updatedAt: Date!
-  createdAt: Date!
+  statusChangeTime: DateTime!
+  updatedAt: DateTime!
+  createdAt: DateTime!
 }
 
 input OfferCreateInput {
@@ -246,9 +247,9 @@ type Pallet {
   palletType: PalletType!
   lineItems: [LineItem!]!
   paymentStatus: PaymentStatus!
-  paymentStatusChangeTime: Date!
-  createdAt: Date!
-  updatedAt: Date!
+  paymentStatusChangeTime: DateTime!
+  createdAt: DateTime!
+  updatedAt: DateTime!
 }
 
 input PalletCreateInput {
@@ -319,9 +320,9 @@ type LineItem {
   dangerousGoods: [DangerousGoods!]!
   photoUris: [String!]!
   sendingHubDeliveryDate: Date
-  statusChangeTime: Date!
-  createdAt: Date!
-  updatedAt: Date!
+  statusChangeTime: DateTime!
+  createdAt: DateTime!
+  updatedAt: DateTime!
 }
 
 input LineItemUpdateInput {
@@ -349,5 +350,5 @@ type ShipmentExport {
   downloadPath: String!
   shipmentId: Int!
   createdBy: UserProfile!
-  createdAt: Date!
+  createdAt: DateTime!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -83,6 +83,8 @@ type Query {
   pallet(id: Int!): Pallet!
 
   lineItem(id: Int!): LineItem!
+
+  listShipmentExports(shipmentId: Int!): [ShipmentExport!]!
 }
 
 type Mutation {

--- a/src/authenticateRequest.ts
+++ b/src/authenticateRequest.ts
@@ -132,7 +132,7 @@ export const authenticateRequest = async (req: Request): Promise<Auth> => {
     return fakeAdminAuth
   }
 
-  const { authorization: token } = req.headers
+  const token = req.headers.authorization || req.query.authorization?.toString()
 
   if (token == null) {
     throw new ForbiddenError('you must be logged in')

--- a/src/generateCsv.ts
+++ b/src/generateCsv.ts
@@ -11,7 +11,7 @@ const convertCsvField = (value: CsvFieldValue) => {
     case 'number':
       return value
     case 'string':
-      return '"' + value.replace(/[\S\s]+/gm, ' ') + '"'
+      return '"' + value.replace(/[\n\s\r\v\t]+/gm, ' ') + '"'
     default:
       throw new Error(
         `unrecognized value type in CSV generation: ${typeof value}`,

--- a/src/models/shipment_export.ts
+++ b/src/models/shipment_export.ts
@@ -24,6 +24,7 @@ export interface ShipmentExportCreationAttributes
 
 @Table({
   createdAt: true,
+  updatedAt: false,
 })
 export default class ShipmentExport extends Model {
   public id!: number

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -25,7 +25,7 @@ import {
   shipmentExports,
   updateShipment,
 } from './shipment'
-import { exportShipment } from './shipment_exports'
+import { exportShipment, listShipmentExports } from './shipment_exports'
 
 const resolvers: Resolvers = {
   // Third Party Resolvers
@@ -41,6 +41,7 @@ const resolvers: Resolvers = {
     listOffers,
     pallet,
     lineItem,
+    listShipmentExports,
   },
 
   // Mutation Resolvers

--- a/src/resolvers/shipment_exports.ts
+++ b/src/resolvers/shipment_exports.ts
@@ -52,6 +52,8 @@ const exportShipment: MutationResolvers['exportShipment'] = async (
     ),
   )
 
+  rows.unshift(HEADER_ROW)
+
   const csv = services.generateCsv(rows)
 
   const exportRecord = await ShipmentExport.create({
@@ -63,6 +65,22 @@ const exportShipment: MutationResolvers['exportShipment'] = async (
   return exportRecord.toWireFormat()
 }
 
+export const HEADER_ROW = [
+  'Sending group',
+  'Contact name',
+  'Contact email',
+  'Contact WhatsApp',
+  'Receiving group',
+  'UK Hub',
+  'Category of aid',
+  'Item description',
+  'Pallet ID',
+  'Container count',
+  'Pallet weight',
+  'Dangerous items',
+  'Sending hub delivery date',
+]
+
 function makeExportRow(
   offer: Offer,
   pallet: Pallet,
@@ -71,7 +89,9 @@ function makeExportRow(
   const contact = offer.contact || offer.sendingGroup.primaryContact
   const receivingGroupName = lineItem?.acceptedReceivingGroup
     ? `${lineItem.acceptedReceivingGroup.name} (accepted)`
-    : `${lineItem?.proposedReceivingGroup?.name} (proposed)`
+    : lineItem?.proposedReceivingGroup
+    ? `${lineItem?.proposedReceivingGroup?.name} (proposed)`
+    : 'unset'
 
   return [
     offer.sendingGroup.name,

--- a/src/resolvers/shipment_exports.ts
+++ b/src/resolvers/shipment_exports.ts
@@ -5,7 +5,7 @@ import Offer from '../models/offer'
 import Pallet from '../models/pallet'
 import Shipment from '../models/shipment'
 import ShipmentExport from '../models/shipment_export'
-import { MutationResolvers } from '../server-internal-types'
+import { MutationResolvers, QueryResolvers } from '../server-internal-types'
 
 const exportShipment: MutationResolvers['exportShipment'] = async (
   _,
@@ -110,4 +110,18 @@ function makeExportRow(
   ]
 }
 
-export { exportShipment }
+const listShipmentExports: QueryResolvers['listShipmentExports'] = async (
+  _,
+  { shipmentId },
+  { auth },
+) => {
+  if (!auth.isAdmin) {
+    throw new ForbiddenError('Must be admin')
+  }
+
+  return (
+    await ShipmentExport.findAll({ where: { shipmentId } })
+  ).map((shipmentExport: ShipmentExport) => shipmentExport.toWireFormat())
+}
+
+export { exportShipment, listShipmentExports }

--- a/src/sendShipmentExportCsv.ts
+++ b/src/sendShipmentExportCsv.ts
@@ -21,8 +21,8 @@ const sendShipmentExportCsv = async (req: Request, res: Response) => {
 
   const filename = shipmentExport.shipment.displayName() + '.csv'
 
-  res.contentType('text/plain')
-  res.set('Content-Disposition', `attachment; filename=${filename}`)
+  res.contentType('text/csv')
+  res.attachment(filename)
   res.send(shipmentExport.contentsCsv)
   res.end()
 }

--- a/src/tests/shipment_exports_api.test.ts
+++ b/src/tests/shipment_exports_api.test.ts
@@ -6,6 +6,7 @@ import Offer from '../models/offer'
 import Pallet from '../models/pallet'
 import Shipment from '../models/shipment'
 import UserAccount from '../models/user_account'
+import { HEADER_ROW } from '../resolvers/shipment_exports'
 import { sequelize } from '../sequelize'
 import {
   GroupType,
@@ -129,6 +130,7 @@ describe('ShipmentExports API', () => {
 
       expect(services.generateCsvCalls[0]).toEqual({
         rows: [
+          HEADER_ROW,
           [
             'group 1',
             'offer contact name',

--- a/src/tests/shipment_exports_api.test.ts
+++ b/src/tests/shipment_exports_api.test.ts
@@ -5,6 +5,7 @@ import LineItem from '../models/line_item'
 import Offer from '../models/offer'
 import Pallet from '../models/pallet'
 import Shipment from '../models/shipment'
+import ShipmentExport from '../models/shipment_export'
 import UserAccount from '../models/user_account'
 import { HEADER_ROW } from '../resolvers/shipment_exports'
 import { sequelize } from '../sequelize'
@@ -16,7 +17,7 @@ import {
   OfferStatus,
   PalletType,
   PaymentStatus,
-  ShipmentExport,
+  ShipmentExport as WireShipmentExport,
   ShipmentStatus,
   ShippingRoute,
 } from '../server-internal-types'
@@ -101,6 +102,20 @@ describe('ShipmentExports API', () => {
   })
 
   describe('exportShipment', () => {
+    const LIST_SHIPMENT_EXPORTS = gql`
+      query($shipmentId: Int!) {
+        listShipmentExports(shipmentId: $shipmentId) {
+          id
+          shipmentId
+          downloadPath
+          createdBy {
+            id
+          }
+          createdAt
+        }
+      }
+    `
+
     const EXPORT_SHIPMENT = gql`
       mutation($shipmentId: Int!) {
         exportShipment(shipmentId: $shipmentId) {
@@ -115,7 +130,7 @@ describe('ShipmentExports API', () => {
       }
     `
 
-    it('exports to CSV and creates a record of the export', async () => {
+    it('exports to CSV and creates a record of the export, lists it', async () => {
       const res = await adminTestServer.mutate<
         { exportShipment: ShipmentExport },
         { shipmentId: number }
@@ -148,6 +163,22 @@ describe('ShipmentExports API', () => {
           ],
         ],
       })
+
+      const listRes = await adminTestServer.query<
+        { listShipmentExports: WireShipmentExport[] },
+        { shipmentId: number }
+      >({
+        query: LIST_SHIPMENT_EXPORTS,
+        variables: {
+          shipmentId: shipment.id,
+        },
+      })
+
+      expect(listRes.errors).toBeUndefined()
+
+      const export1 = listRes.data?.listShipmentExports?.[0]!
+
+      expect(export1.shipmentId).toEqual(shipment.id)
     })
   })
 })


### PR DESCRIPTION
### Changes

- adds a button on the Shipment page to download the shipment's data as a CSV file.
- adds a list of previous shipment exports that can be downloaded
- parse the `createdAt` timestamps as `DateTime` instead of `Date`

### Pixels

Previous versions in the UI:

<img width="426" alt="Screen Shot 2021-04-11 at 10 01 53 AM" src="https://user-images.githubusercontent.com/3411183/114313814-f62b0900-9aac-11eb-9a50-8eb3b5aa1827.png">

Screenshot of a CSV:

<img width="500" alt="Screen Shot 2021-04-10 at 4 54 18 PM" src="https://user-images.githubusercontent.com/3411183/114287660-69853a00-9a1d-11eb-9eed-2bc8ad77a5da.png">

