### PR TITLE
Create an onboarding flow for new group leaders

### DIFF
--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -34,7 +34,7 @@ const ButtonLink: FunctionComponent<ButtonProps> & {
   const { className, children } = otherProps
 
   const classes = cx(
-    'inline-flex items-center border text-center text-sm leading-5 font-medium rounded whitespace-no-wrap focus:outline-none focus:ring-4 transition ease-in-out duration-100',
+    'inline-flex items-center border justify-center text-sm leading-5 font-medium rounded whitespace-no-wrap focus:outline-none focus:ring-4 transition ease-in-out duration-100',
     className,
     {
       // Default

--- a/frontend/src/components/TopNavigation.tsx
+++ b/frontend/src/components/TopNavigation.tsx
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react'
-import { FunctionComponent, ReactNode, useContext, useMemo } from 'react'
+import { FunctionComponent, ReactNode, useContext } from 'react'
 import { Link } from 'react-router-dom'
 import ROUTES from '../utils/routes'
 import DistributeAidLogo from './branding/DistributeAidLogo'
@@ -49,12 +49,9 @@ const TopNavigation: FunctionComponent<Props> = ({ hideControls }) => {
   const { user, logout } = useAuth0()
   const { profile } = useContext(UserProfileContext)
 
-  const filteredNavLinks = useMemo(() => {
-    if (!profile?.isAdmin) {
-      return NAV_LINKS.filter((link) => !link.adminOnly)
-    }
-    return NAV_LINKS
-  }, [profile])
+  const filteredNavLinks = NAV_LINKS.filter(
+    (link) => link.adminOnly === profile?.isAdmin,
+  )
 
   return (
     <header className="py-2 bg-navy-800 h-nav sticky top-0">

--- a/frontend/src/components/TopNavigation.tsx
+++ b/frontend/src/components/TopNavigation.tsx
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react'
-import { FunctionComponent, ReactNode } from 'react'
+import { FunctionComponent, ReactNode, useContext, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import ROUTES from '../utils/routes'
 import DistributeAidLogo from './branding/DistributeAidLogo'
@@ -9,11 +9,13 @@ import TruckIcon from './icons/TruckIcon'
 import UserIcon from './icons/UserIcon'
 import DesktopNavigation from './navigation/DesktopNavigation'
 import MobileNavigation from './navigation/MobileNavigation'
+import { UserProfileContext } from './UserProfileContext'
 
 export interface NavLinkItem {
   path: string
   label: ReactNode
   icon?: ReactNode
+  adminOnly?: boolean
 }
 
 const NAV_LINKS: NavLinkItem[] = [
@@ -26,6 +28,7 @@ const NAV_LINKS: NavLinkItem[] = [
     path: ROUTES.ADMIN_ROOT,
     label: 'Admin',
     icon: <CogIcon className="w-5 h-5 mr-2" />,
+    adminOnly: true,
   },
 ]
 
@@ -44,17 +47,25 @@ interface Props {
  */
 const TopNavigation: FunctionComponent<Props> = ({ hideControls }) => {
   const { user, logout } = useAuth0()
+  const { profile } = useContext(UserProfileContext)
+
+  const filteredNavLinks = useMemo(() => {
+    if (!profile?.isAdmin) {
+      return NAV_LINKS.filter((link) => !link.adminOnly)
+    }
+    return NAV_LINKS
+  }, [profile])
 
   return (
     <header className="py-2 bg-navy-800 h-nav sticky top-0">
       <div className="max-w-5xl px-4 mx-auto h-full flex items-center justify-between">
-        <MobileNavigation navLinks={NAV_LINKS} />
+        <MobileNavigation navLinks={filteredNavLinks} />
         <div className="flex items-center">
           <Link to="/" className="text-white" aria-label="Go to the home page">
             <DistributeAidLogo className="block h-8" />
           </Link>
         </div>
-        <DesktopNavigation navLinks={NAV_LINKS} />
+        <DesktopNavigation navLinks={filteredNavLinks} />
         {!hideControls && user && (
           <div className="flex items-center text-white">
             <DropdownMenu

--- a/frontend/src/components/UserProfileContext.tsx
+++ b/frontend/src/components/UserProfileContext.tsx
@@ -4,6 +4,15 @@ import { createContext, FunctionComponent, useEffect, useState } from 'react'
 export interface UserProfile {
   id: number
   isAdmin: boolean
+  groupId?: number
+}
+
+interface UserProfileData {
+  profile?: UserProfile
+  /**
+   * Call this method to refresh the values stored in the UserProfile
+   */
+  refetch: () => void
 }
 
 const fetchProfile = (token: string) => {
@@ -12,12 +21,16 @@ const fetchProfile = (token: string) => {
   })
 }
 
-const UserProfileContext = createContext<UserProfile | undefined>(undefined)
+const UserProfileContext = createContext<UserProfileData>({
+  refetch: () => {},
+})
 
 const UserProfileProvider: FunctionComponent = ({ children }) => {
   const { isAuthenticated, getAccessTokenSilently } = useAuth0()
   const [profileIsLoaded, setProfileIsLoaded] = useState(false)
   const [profile, setProfile] = useState<UserProfile>()
+
+  const refetch = () => setProfileIsLoaded(false)
 
   useEffect(() => {
     if (isAuthenticated && !profileIsLoaded) {
@@ -39,7 +52,7 @@ const UserProfileProvider: FunctionComponent = ({ children }) => {
   }, [isAuthenticated, getAccessTokenSilently, profileIsLoaded])
 
   return (
-    <UserProfileContext.Provider value={profile}>
+    <UserProfileContext.Provider value={{ profile, refetch }}>
       {children}
     </UserProfileContext.Provider>
   )

--- a/frontend/src/components/forms/SelectField.tsx
+++ b/frontend/src/components/forms/SelectField.tsx
@@ -1,4 +1,5 @@
 import { ErrorMessage } from '@hookform/error-message'
+import cx from 'classnames'
 import _get from 'lodash/get'
 import { nanoid } from 'nanoid'
 import {
@@ -82,6 +83,7 @@ const SelectField: FunctionComponent<Props> = ({
   label,
   errors,
   options = [],
+  className,
   ...otherProps
 }) => {
   // Create a unique ID in case the use doesn't provide one
@@ -94,7 +96,7 @@ const SelectField: FunctionComponent<Props> = ({
   const hasError = _get(errors, otherProps.name, null) != null
 
   return (
-    <div className="w-full">
+    <div className={cx(className, 'w-full')}>
       <Label htmlFor={fieldId} required={otherProps.required}>
         {label}
       </Label>

--- a/frontend/src/components/icons/CheckIcon.tsx
+++ b/frontend/src/components/icons/CheckIcon.tsx
@@ -1,0 +1,19 @@
+import { FunctionComponent, SVGProps } from 'react'
+
+const CheckIcon: FunctionComponent<SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className="h-5 w-5"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+      clipRule="evenodd"
+    />
+  </svg>
+)
+
+export default CheckIcon

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,23 +1,25 @@
-import { Link } from 'react-router-dom'
+import { useContext } from 'react'
+import { UserProfileContext } from '../components/UserProfileContext'
 import LayoutWithNav from '../layouts/LayoutWithNav'
+import GroupLeaderHomePage from './home/GroupLeaderHomePage'
 
-const HomePage = () => (
-  <LayoutWithNav>
-    <main className="flex flex-col items-center justify-center min-h-half-screen p-4">
-      <h1 className="text-xl md:text-3xl text-gray-800">
-        Welcome to the Shipment Tracker! 📦👀
-      </h1>
-      <p className="mt-6 text-lg text-gray-700">
-        This app is built with React, Typescript, and Tailwind.
-      </p>
-      <p className="mt-6 text-lg text-gray-700">
-        View a demo of{' '}
-        <Link className="text-blue-700 hover:underline" to="/apollo-demo">
-          using Apollo and GraphQL
-        </Link>
-      </p>
-    </main>
-  </LayoutWithNav>
-)
+const HomePage = () => {
+  const { profile } = useContext(UserProfileContext)
+
+  const userIsGroupLeader = profile?.isAdmin === false
+
+  return (
+    <LayoutWithNav>
+      <main className="flex flex-col items-center justify-center min-h-half-screen">
+        <section className="bg-white p-4 md:p-8 lg:p-16 shadow rounded-lg">
+          <h1 className="text-xl md:text-3xl text-gray-800 mb-8">
+            Welcome to the Shipment Tracker! 📦
+          </h1>
+          {userIsGroupLeader && <GroupLeaderHomePage />}
+        </section>
+      </main>
+    </LayoutWithNav>
+  )
+}
 
 export default HomePage

--- a/frontend/src/pages/groups/GroupCreatePage.tsx
+++ b/frontend/src/pages/groups/GroupCreatePage.tsx
@@ -11,7 +11,9 @@ import { groupViewRoute } from '../../utils/routes'
 import GroupForm from './GroupForm'
 
 const GroupCreatePage: FunctionComponent = () => {
-  const { refetch } = useContext(UserProfileContext)
+  const { refetch: refreshUserGroupAssociation } = useContext(
+    UserProfileContext,
+  )
   const history = useHistory()
 
   const [
@@ -28,10 +30,10 @@ const GroupCreatePage: FunctionComponent = () => {
         refetchQueries: [{ query: AllGroupsDocument }],
       })
 
-      // If the user is a group leader, refresh their credentials so that the UI
-      // is aware that they created their own group and finished their
-      // onboarding
-      refetch()
+      // Because we cache the association between a group captain and their
+      // group, we need to refresh that association when they create their first
+      // group.
+      refreshUserGroupAssociation()
 
       if (data) {
         const newGroupId = data.addGroup.id

--- a/frontend/src/pages/groups/GroupCreatePage.tsx
+++ b/frontend/src/pages/groups/GroupCreatePage.tsx
@@ -1,5 +1,6 @@
-import { FunctionComponent } from 'react'
+import { FunctionComponent, useContext } from 'react'
 import { useHistory } from 'react-router-dom'
+import { UserProfileContext } from '../../components/UserProfileContext'
 import LayoutWithNav from '../../layouts/LayoutWithNav'
 import {
   AllGroupsDocument,
@@ -10,6 +11,7 @@ import { groupViewRoute } from '../../utils/routes'
 import GroupForm from './GroupForm'
 
 const GroupCreatePage: FunctionComponent = () => {
+  const { refetch } = useContext(UserProfileContext)
   const history = useHistory()
 
   const [
@@ -17,20 +19,27 @@ const GroupCreatePage: FunctionComponent = () => {
     { loading: mutationIsLoading, error: mutationError },
   ] = useCreateGroupMutation()
 
-  const onSubmit = (input: GroupCreateInput) => {
-    // Create the group and then redirect to its view/edit page
-    addGroup({
-      variables: { input },
-      // Fetch the updated list of groups
-      refetchQueries: [{ query: AllGroupsDocument }],
-    })
-      .then(({ data }) => {
-        if (data) {
-          const newGroupId = data.addGroup.id
-          history.push(groupViewRoute(newGroupId))
-        }
+  const onSubmit = async (input: GroupCreateInput) => {
+    try {
+      // Create the group and then redirect to its view/edit page
+      const { data } = await addGroup({
+        variables: { input },
+        // Fetch the updated list of groups
+        refetchQueries: [{ query: AllGroupsDocument }],
       })
-      .catch(console.error)
+
+      // If the user is a group leader, refresh their credentials so that the UI
+      // is aware that they created their own group and finished their
+      // onboarding
+      refetch()
+
+      if (data) {
+        const newGroupId = data.addGroup.id
+        history.push(groupViewRoute(newGroupId))
+      }
+    } catch (error) {
+      console.error(error)
+    }
   }
 
   return (

--- a/frontend/src/pages/groups/GroupEditPage.tsx
+++ b/frontend/src/pages/groups/GroupEditPage.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react'
-import { useParams } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 import InternalLink from '../../components/InternalLink'
 import LayoutWithNav from '../../layouts/LayoutWithNav'
 import {
@@ -11,6 +11,8 @@ import { groupViewRoute } from '../../utils/routes'
 import GroupForm from './GroupForm'
 
 const GroupEditPage: FunctionComponent = () => {
+  const history = useHistory()
+
   // Extract the group's ID from the URL
   const { groupId } = useParams<{ groupId: string }>()
 
@@ -25,10 +27,15 @@ const GroupEditPage: FunctionComponent = () => {
     { loading: mutationIsLoading, error: mutationError },
   ] = useUpdateGroupMutation()
 
-  const onSubmit = (input: GroupUpdateInput) => {
-    updateGroup({ variables: { id: parseInt(groupId, 10), input } }).catch(
-      console.error,
-    )
+  const onSubmit = async (input: GroupUpdateInput) => {
+    try {
+      await updateGroup({
+        variables: { id: parseInt(groupId, 10), input },
+      })
+      history.push(groupViewRoute(groupId))
+    } catch (error) {
+      console.error(error)
+    }
   }
 
   return (

--- a/frontend/src/pages/groups/GroupViewPage.tsx
+++ b/frontend/src/pages/groups/GroupViewPage.tsx
@@ -1,32 +1,42 @@
-import { FunctionComponent } from 'react'
+import { FunctionComponent, useContext } from 'react'
 import { useParams } from 'react-router-dom'
 import ButtonLink from '../../components/ButtonLink'
 import ReadOnlyField from '../../components/forms/ReadOnlyField'
 import InternalLink from '../../components/InternalLink'
+import { UserProfileContext } from '../../components/UserProfileContext'
 import LayoutWithNav from '../../layouts/LayoutWithNav'
 import { useGroupQuery } from '../../types/api-types'
 import { formatCountryCodeToName, formatGroupType } from '../../utils/format'
 import ROUTES, { groupEditRoute } from '../../utils/routes'
 
 const GroupViewPage: FunctionComponent = () => {
+  const { profile } = useContext(UserProfileContext)
+
   // Extract the group's ID from the URL
-  const { groupId } = useParams<{ groupId: string }>()
+  const groupId = parseInt(useParams<{ groupId: string }>().groupId, 10)
 
   // Load the group's information
   const { data: group } = useGroupQuery({
-    variables: { id: parseInt(groupId, 10) },
+    variables: { id: groupId },
   })
 
   const groupData = group?.group
+
+  const canEditGroup = profile?.isAdmin || profile?.groupId === groupId
 
   return (
     <LayoutWithNav>
       <div className="max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content">
         <header className="p-4 md:p-6 border-b border-gray-200 md:flex items-center">
           <div className="flex-grow">
-            <InternalLink className="inline-block mb-2" to={ROUTES.GROUP_LIST}>
-              ← back to list
-            </InternalLink>
+            {profile?.isAdmin && (
+              <InternalLink
+                className="inline-block mb-2"
+                to={ROUTES.GROUP_LIST}
+              >
+                ← back to list
+              </InternalLink>
+            )}
             <h1 className="text-navy-800 text-2xl md:text-3xl mb-2">
               {groupData?.name}
             </h1>
@@ -35,9 +45,11 @@ const GroupViewPage: FunctionComponent = () => {
               services across the world.
             </p>
           </div>
-          <div className="flex-shrink mt-4 md:mt-0">
-            <ButtonLink to={groupEditRoute(groupId)}>Edit</ButtonLink>
-          </div>
+          {canEditGroup && (
+            <div className="flex-shrink mt-4 md:mt-0">
+              <ButtonLink to={groupEditRoute(groupId)}>Edit</ButtonLink>
+            </div>
+          )}
         </header>
         {groupData && (
           <main className="p-4 md:p-6 max-w-lg pb-20 space-y-6">

--- a/frontend/src/pages/home/GroupLeaderHomePage.tsx
+++ b/frontend/src/pages/home/GroupLeaderHomePage.tsx
@@ -1,0 +1,73 @@
+import { FunctionComponent, useContext } from 'react'
+import ButtonLink from '../../components/ButtonLink'
+import CheckIcon from '../../components/icons/CheckIcon'
+import CogIcon from '../../components/icons/CogIcon'
+import TruckIcon from '../../components/icons/TruckIcon'
+import InternalLink from '../../components/InternalLink'
+import { UserProfileContext } from '../../components/UserProfileContext'
+import ROUTES, { groupViewRoute } from '../../utils/routes'
+
+const GroupLeaderHomePage: FunctionComponent = () => {
+  const { profile } = useContext(UserProfileContext)
+
+  const groupLeaderHasCreatedGroup = profile?.groupId != null
+
+  if (groupLeaderHasCreatedGroup) {
+    return (
+      <div>
+        <h2 className="text-gray-700 font-medium mb-2 text-lg">Quick links</h2>
+        <ul>
+          <li>
+            <InternalLink
+              to={ROUTES.SHIPMENT_LIST}
+              className="inline-flex items-center"
+            >
+              <TruckIcon className="w-4 h-4 mr-1" /> Shipments
+            </InternalLink>
+          </li>
+          <li>
+            <InternalLink
+              to={groupViewRoute(profile?.groupId!)}
+              className="inline-flex items-center"
+            >
+              <CogIcon className="w-4 h-4 mr-1" />
+              Group settings
+            </InternalLink>
+          </li>
+        </ul>
+        <h2 className="text-gray-700 font-medium mb-2 mt-8 text-lg">
+          Onboarding
+        </h2>
+        <p className="text-gray-500">You've completed the onboarding.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <h2 className="text-gray-700 font-medium mb-4 text-lg">Onboarding</h2>
+      <div className="rounded border border-gray-200 p-4 relative mb-4">
+        <CheckIcon className="w-6 h-6 absolute -right-2 -top-2 text-green-700" />
+        <div className="font-semibold text-gray-600">1. Create an account</div>
+        <div className="text-gray-500">This step is complete</div>
+      </div>
+      <div className="rounded border border-gray-200 p-4 relative md:flex items-center">
+        <div className="flex-grow mb-4 md:mb-0">
+          <div className="font-semibold text-gray-600">
+            2. Set up your sending group
+          </div>
+          <div className="text-gray-500">Fill out a short questionnaire</div>
+        </div>
+        <ButtonLink
+          className="w-full md:w-auto"
+          variant="primary"
+          to={ROUTES.GROUP_CREATE}
+        >
+          Create group
+        </ButtonLink>
+      </div>
+    </div>
+  )
+}
+
+export default GroupLeaderHomePage

--- a/frontend/src/pages/offers/CreateOfferForm.tsx
+++ b/frontend/src/pages/offers/CreateOfferForm.tsx
@@ -35,7 +35,7 @@ const OfferForm: FunctionComponent<Props> = (props) => {
   // Each group leader is assigned to a single group
   // We need to figure out which group that is
   // TODO: handle the fact that admins can be assigned to any number of groups
-  const profile = useContext(UserProfileContext)
+  const { profile } = useContext(UserProfileContext)
   const { data: groups, loading: isLoadingGroups } = useAllGroupsMinimalQuery()
 
   const groupForUser = useMemo(() => {

--- a/frontend/src/pages/offers/LineItemForm.tsx
+++ b/frontend/src/pages/offers/LineItemForm.tsx
@@ -81,9 +81,9 @@ const LineItemForm: FunctionComponent<Props> = ({
     // react-hook-form
     input.dangerousGoods = dangerousGoodsList
 
-    // We need to all the fields from LineItemUpdateInput, even the ones that
-    // didn't change. We then _pick the fields to make sure we don't send things
-    // like `id` or `__typename`
+    // We need to send all the fields from LineItemUpdateInput, even the ones
+    // that didn't change. We then _pick the fields to make sure we don't send
+    // things like `id` or `__typename`.
     const updatedLineItem = _pick(Object.assign({}, data.lineItem, input), [
       'status',
       'proposedReceivingGroupId',

--- a/frontend/src/pages/shipments/ShipmentViewPage.tsx
+++ b/frontend/src/pages/shipments/ShipmentViewPage.tsx
@@ -18,7 +18,7 @@ import ShipmentDetails from './ShipmentDetails'
 import ShipmentOffers from './ShipmentOffers'
 
 const ShipmentViewPage: FunctionComponent = () => {
-  const user = useContext(UserProfileContext)
+  const { profile } = useContext(UserProfileContext)
   const params = useParams<{ shipmentId: string }>()
   const shipmentId = parseInt(params.shipmentId, 10)
 
@@ -44,7 +44,7 @@ const ShipmentViewPage: FunctionComponent = () => {
             </h1>
           </div>
           <div className="flex-shrink space-x-4 mt-4 md:mt-0">
-            {user?.isAdmin && shipment && (
+            {profile?.isAdmin && shipment && (
               <DownloadCSVMenu shipment={shipment.shipment} />
             )}
             <ButtonLink to={shipmentEditRoute(shipmentId)}>Edit</ButtonLink>

--- a/schema.graphql
+++ b/schema.graphql
@@ -187,6 +187,7 @@ enum GroupType {
 type UserProfile {
   id: Int!
   isAdmin: Boolean!
+  groupId: Int
 }
 
 enum OfferStatus {

--- a/src/findOrCreateProfile.ts
+++ b/src/findOrCreateProfile.ts
@@ -9,7 +9,7 @@ const sendProfile = (
   userAccount: UserAccount,
   isAdmin = false,
   groupId?: number,
-) => response.json(userAccount.asProfile(isAdmin, groupId)).end()
+) => response.json(userAccount.asProfile(groupId, isAdmin)).end()
 
 const findOrCreateProfile = async (request: Request, response: Response) => {
   const auth = await authenticateRequest(request)
@@ -19,6 +19,11 @@ const findOrCreateProfile = async (request: Request, response: Response) => {
 
     let groupForUser: Maybe<Group>
     if (!auth.isAdmin) {
+      // Note: this assumes that there is only 1 captain per group, where in
+      // reality there are no restrictions on the number of groups with the same
+      // captain. For now, we've agreed that this is okay, but we probably need
+      // to solidify some restrictions later on.
+      // See https://github.com/distributeaid/shipment-tracker/issues/133
       groupForUser = await Group.findOne({
         where: { captainId: auth.userAccount.id },
         attributes: ['id'],

--- a/src/models/user_account.ts
+++ b/src/models/user_account.ts
@@ -36,7 +36,7 @@ export default class UserAccount extends Model<
   @Column
   public readonly updatedAt!: Date
 
-  public asProfile(isAdmin = false, groupId?: number): UserProfile {
+  public asProfile(groupId?: number, isAdmin = false): UserProfile {
     return {
       id: this.id,
       isAdmin,

--- a/src/models/user_account.ts
+++ b/src/models/user_account.ts
@@ -36,10 +36,11 @@ export default class UserAccount extends Model<
   @Column
   public readonly updatedAt!: Date
 
-  public asProfile(isAdmin = false): UserProfile {
+  public asProfile(isAdmin = false, groupId?: number): UserProfile {
     return {
       id: this.id,
       isAdmin,
+      groupId,
     }
   }
 }

--- a/src/resolvers/group.ts
+++ b/src/resolvers/group.ts
@@ -4,6 +4,7 @@ import Group, { GroupAttributes } from '../models/group'
 import UserAccount from '../models/user_account'
 import {
   GroupCreateInput,
+  GroupType,
   MutationResolvers,
   QueryResolvers,
 } from '../server-internal-types'
@@ -41,6 +42,11 @@ const addGroup: MutationResolvers['addGroup'] = async (
     })
   }
 
+  // Non-admins should only be allowed to create sending groups
+  if (input.groupType !== GroupType.SendingGroup && !context.auth.isAdmin) {
+    throw new ForbiddenError(`Non-admins can only create sending groups`)
+  }
+
   if (input.website && !stringIsUrl(input.website)) {
     throw new UserInputError(`URL is not valid: ${input.website}`)
   }
@@ -73,7 +79,7 @@ const updateGroup: MutationResolvers['updateGroup'] = async (
     throw new ForbiddenError('Not permitted to update group')
   }
 
-  if (input.groupType && !context.auth.isAdmin) {
+  if (input.groupType !== group.groupType && !context.auth.isAdmin) {
     throw new ForbiddenError('Not permitted to change group type')
   }
 

--- a/src/resolvers/group.ts
+++ b/src/resolvers/group.ts
@@ -79,7 +79,11 @@ const updateGroup: MutationResolvers['updateGroup'] = async (
     throw new ForbiddenError('Not permitted to update group')
   }
 
-  if (input.groupType !== group.groupType && !context.auth.isAdmin) {
+  if (
+    input.groupType &&
+    input.groupType !== group.groupType &&
+    !context.auth.isAdmin
+  ) {
     throw new ForbiddenError('Not permitted to change group type')
   }
 

--- a/src/tests/groups_api.test.ts
+++ b/src/tests/groups_api.test.ts
@@ -1,13 +1,13 @@
-import gql from 'graphql-tag'
 import { ApolloServerTestClient } from 'apollo-server-testing'
+import gql from 'graphql-tag'
 import { omit } from 'lodash'
-import { makeAdminTestServer, makeTestServer } from '../testServer'
-import { sequelize } from '../sequelize'
-import Group, { GroupAttributes } from '../models/group'
-import { createGroup } from './helpers'
-import { GroupType } from '../server-internal-types'
-import UserAccount from '../models/user_account'
 import { fakeUserAuth } from '../authenticateRequest'
+import Group, { GroupAttributes } from '../models/group'
+import UserAccount from '../models/user_account'
+import { sequelize } from '../sequelize'
+import { GroupType } from '../server-internal-types'
+import { makeAdminTestServer, makeTestServer } from '../testServer'
+import { createGroup } from './helpers'
 
 describe('Groups API', () => {
   let otherUserTestServer: ApolloServerTestClient,
@@ -19,7 +19,7 @@ describe('Groups API', () => {
   const group1Name: string = 'group1'
   const group1Params = {
     name: group1Name,
-    groupType: GroupType.DaHub,
+    groupType: GroupType.SendingGroup,
     primaryLocation: { countryCode: 'UK', townCity: 'Bristol' },
     primaryContact: { name: 'Contact', email: 'contact@example.com' },
     website: 'http://www.example.com',


### PR DESCRIPTION
Resolves #128.

### Changes

- added an onboarding flow for new group leaders
- disabled various UI elements that group leaders shouldn't be allowed to access
- added some restrictions to the Groups API
- added the user's group to their profile information

### Pixels

[🎥 Video showing the new flow from a user perspective](https://www.loom.com/share/f0b29bae40e5407e91d6c0a5f9bf839a)

Home page with onboarding steps:
<img width="400" alt="Screen Shot 2021-04-11 at 9 45 20 PM" src="https://user-images.githubusercontent.com/3411183/114341757-581c5a80-9b0f-11eb-8f88-8c5251000c70.png">


Home page after the onboarding is complete:
<img width="400" alt="Screen Shot 2021-04-11 at 9 44 46 PM" src="https://user-images.githubusercontent.com/3411183/114341772-5fdbff00-9b0f-11eb-9801-2082ae8c7b81.png">
