### PR TITLE
Allow changing the status of offers

### DIFF
--- a/frontend/src/components/icons/WarningIcon.tsx
+++ b/frontend/src/components/icons/WarningIcon.tsx
@@ -1,0 +1,18 @@
+import { FunctionComponent, SVGProps } from 'react'
+
+const CogIcon: FunctionComponent<SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+      clipRule="evenodd"
+    />
+  </svg>
+)
+
+export default CogIcon

--- a/frontend/src/components/icons/WarningIcon.tsx
+++ b/frontend/src/components/icons/WarningIcon.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, SVGProps } from 'react'
 
-const CogIcon: FunctionComponent<SVGProps<SVGSVGElement>> = (props) => (
+const WarningIcon: FunctionComponent<SVGProps<SVGSVGElement>> = (props) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="currentColor"
@@ -15,4 +15,4 @@ const CogIcon: FunctionComponent<SVGProps<SVGSVGElement>> = (props) => (
   </svg>
 )
 
-export default CogIcon
+export default WarningIcon

--- a/frontend/src/pages/groups/GroupForm.tsx
+++ b/frontend/src/pages/groups/GroupForm.tsx
@@ -1,4 +1,3 @@
-import _omit from 'lodash/omit'
 import { FunctionComponent, ReactNode, useContext, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import Button from '../../components/Button'
@@ -7,6 +6,7 @@ import TextField from '../../components/forms/TextField'
 import { UserProfileContext } from '../../components/UserProfileContext'
 import { COUNTRY_CODE_OPTIONS, GROUP_TYPE_OPTIONS } from '../../data/constants'
 import { GroupCreateInput, GroupQuery, GroupType } from '../../types/api-types'
+import { stripIdAndTypename } from '../../utils/types'
 
 interface Props {
   /**
@@ -45,7 +45,7 @@ const GroupForm: FunctionComponent<Props> = (props) => {
     function resetFormValues() {
       if (props.defaultValues) {
         // Update the values of the fields
-        reset(_omit(props.defaultValues.group, ['id', '__typename']))
+        reset(stripIdAndTypename(props.defaultValues.group))
       }
     },
     [props.defaultValues, reset],

--- a/frontend/src/pages/offers/OfferStatusSwitcher.tsx
+++ b/frontend/src/pages/offers/OfferStatusSwitcher.tsx
@@ -1,0 +1,82 @@
+import { FunctionComponent, useContext } from 'react'
+import Badge from '../../components/Badge'
+import Button from '../../components/Button'
+import ReadOnlyField from '../../components/forms/ReadOnlyField'
+import { UserProfileContext } from '../../components/UserProfileContext'
+import { OfferStatus } from '../../types/api-types'
+
+interface Props {
+  currentOfferStatus: OfferStatus
+  updateStatus: (status: OfferStatus) => void
+}
+
+/**
+ * This component allows users to step through the Offer workflow:
+ * 1. Draft
+ * 2. Proposed
+ * 3. In review
+ * 4. Accepted or Rejected
+ */
+const OfferStatusSwitcher: FunctionComponent<Props> = ({
+  currentOfferStatus,
+  updateStatus,
+}) => {
+  const userProfile = useContext(UserProfileContext)
+  const userIsAdmin = userProfile.profile?.isAdmin
+
+  if (currentOfferStatus === OfferStatus.Draft) {
+    return (
+      <Button onClick={() => updateStatus(OfferStatus.Proposed)}>
+        Ready for review
+      </Button>
+    )
+  }
+
+  if (!userIsAdmin) {
+    const content = {
+      [OfferStatus.Proposed]: 'This offer is awaiting review',
+      [OfferStatus.BeingReviewed]: 'An admin is reviewing this offer',
+      [OfferStatus.Accepted]: 'This offer was approved',
+      [OfferStatus.Rejected]: 'This offer was rejected',
+    }
+
+    return <p>{content[currentOfferStatus]}</p>
+  }
+
+  if (currentOfferStatus === OfferStatus.Proposed) {
+    return (
+      <Button onClick={() => updateStatus(OfferStatus.BeingReviewed)}>
+        Start review
+      </Button>
+    )
+  }
+
+  if (currentOfferStatus === OfferStatus.BeingReviewed) {
+    return (
+      <div className="flex flex-col space-y-2">
+        <Button onClick={() => updateStatus(OfferStatus.Rejected)}>
+          Reject offer
+        </Button>
+        <Button onClick={() => updateStatus(OfferStatus.Accepted)}>
+          Approve offer
+        </Button>
+      </div>
+    )
+  }
+
+  if (currentOfferStatus === OfferStatus.Accepted) {
+    return (
+      <ReadOnlyField label="Status">
+        <Badge color="green">Accepted</Badge>
+      </ReadOnlyField>
+    )
+  }
+
+  return (
+    <ReadOnlyField label="Status">
+      <Badge color="red">Rejected</Badge>
+    </ReadOnlyField>
+  )
+}
+
+export default OfferStatusSwitcher

--- a/frontend/src/pages/offers/OfferStatusSwitcher.tsx
+++ b/frontend/src/pages/offers/OfferStatusSwitcher.tsx
@@ -40,7 +40,11 @@ const OfferStatusSwitcher: FunctionComponent<Props> = ({
       [OfferStatus.Rejected]: 'This offer was rejected',
     }
 
-    return <p>{content[currentOfferStatus]}</p>
+    return (
+      <ReadOnlyField label="Status">
+        {content[currentOfferStatus]}
+      </ReadOnlyField>
+    )
   }
 
   if (currentOfferStatus === OfferStatus.Proposed) {

--- a/frontend/src/pages/offers/PalletsEditor.tsx
+++ b/frontend/src/pages/offers/PalletsEditor.tsx
@@ -127,10 +127,11 @@ const PalletsEditor: FunctionComponent<Props> = ({ offerId, pallets = [] }) => {
           </Button>
         </div>
         <ul className="divide-y divide-gray-100">
-          {pallets.map((pallet) => (
+          {pallets.map((pallet, index) => (
             <li
               key={pallet.id}
               className="bg-white"
+              data-qa={`pallet-${pallet.id}`}
               onClick={() => selectPallet(pallet.id)}
             >
               <div className="bg-white">
@@ -155,7 +156,7 @@ const PalletsEditor: FunctionComponent<Props> = ({ offerId, pallets = [] }) => {
                       pallet.id === selectedPalletId ? 'down' : 'right'
                     }
                   />
-                  Pallet {pallet.id}
+                  Pallet {index + 1}
                 </div>
                 {selectedPalletId === pallet.id && (
                   <div className="flex flex-col pb-4 pr-4 pl-8">

--- a/frontend/src/pages/offers/ViewLineItem.tsx
+++ b/frontend/src/pages/offers/ViewLineItem.tsx
@@ -1,6 +1,7 @@
-import { FunctionComponent, useEffect } from 'react'
+import React, { FunctionComponent, useEffect } from 'react'
 import Button from '../../components/Button'
 import ReadOnlyField from '../../components/forms/ReadOnlyField'
+import WarningIcon from '../../components/icons/WarningIcon'
 import ConfirmationModal from '../../components/modal/ConfirmationModal'
 import Spinner from '../../components/Spinner'
 import useModalState from '../../hooks/useModalState'
@@ -10,7 +11,11 @@ import {
   useDestroyLineItemMutation,
   useLineItemQuery,
 } from '../../types/api-types'
-import { formatLineItemCategory } from '../../utils/format'
+import {
+  formatContainerType,
+  formatLineItemCategory,
+  getLineItemVolume,
+} from '../../utils/format'
 
 interface Props {
   /**
@@ -118,9 +123,9 @@ const ViewLineItem: FunctionComponent<Props> = ({
             <ReadOnlyField label="Description">
               {data.lineItem.description || 'No description provided'}
             </ReadOnlyField>
-            <div className="md:flex md:space-x-4">
+            <div className="md:flex md:space-x-8">
               <ReadOnlyField label="Container">
-                {data.lineItem.containerType}
+                {formatContainerType(data.lineItem.containerType)}
               </ReadOnlyField>
               <ReadOnlyField label="Number of items">
                 {data.lineItem.itemCount || 0}
@@ -134,7 +139,7 @@ const ViewLineItem: FunctionComponent<Props> = ({
             <legend className="font-semibold text-gray-700 ">
               Dimensions and weight
             </legend>
-            <div className="md:flex md:space-x-4">
+            <div className="md:flex md:space-x-8">
               <ReadOnlyField label="Width">
                 {data.lineItem.containerWidthCm || 0}cm
               </ReadOnlyField>
@@ -144,8 +149,11 @@ const ViewLineItem: FunctionComponent<Props> = ({
               <ReadOnlyField label="Height">
                 {data.lineItem.containerHeightCm || 0}cm
               </ReadOnlyField>
+              <ReadOnlyField label="Volume">
+                {getLineItemVolume(data.lineItem)}
+              </ReadOnlyField>
             </div>
-            <div className="md:flex md:space-x-4">
+            <div className="md:flex md:space-x-8">
               <ReadOnlyField label="Weight">
                 {data.lineItem.containerWeightGrams || 0}g
               </ReadOnlyField>
@@ -165,6 +173,7 @@ const ViewLineItem: FunctionComponent<Props> = ({
                 {data.lineItem.dangerousGoods
                   .map((item) => item.toLowerCase())
                   .join(', ')}
+                <WarningIcon className="w-5 h-5 ml-2 inline-block" />
               </p>
             )}
           </fieldset>

--- a/frontend/src/pages/offers/ViewLineItem.tsx
+++ b/frontend/src/pages/offers/ViewLineItem.tsx
@@ -14,7 +14,7 @@ import {
 import {
   formatContainerType,
   formatLineItemCategory,
-  getLineItemVolume,
+  getLineItemVolumeInSquareMeters,
 } from '../../utils/format'
 
 interface Props {
@@ -150,7 +150,7 @@ const ViewLineItem: FunctionComponent<Props> = ({
                 {data.lineItem.containerHeightCm || 0}cm
               </ReadOnlyField>
               <ReadOnlyField label="Volume">
-                {getLineItemVolume(data.lineItem)}
+                {getLineItemVolumeInSquareMeters(data.lineItem)}
               </ReadOnlyField>
             </div>
             <div className="md:flex md:space-x-8">

--- a/frontend/src/pages/offers/ViewOfferPage.tsx
+++ b/frontend/src/pages/offers/ViewOfferPage.tsx
@@ -1,4 +1,3 @@
-import _omit from 'lodash/omit'
 import { FunctionComponent } from 'react'
 import { useParams } from 'react-router-dom'
 import ReadOnlyField from '../../components/forms/ReadOnlyField'
@@ -16,6 +15,7 @@ import {
 } from '../../types/api-types'
 import { formatShipmentName } from '../../utils/format'
 import { shipmentViewOffersRoute } from '../../utils/routes'
+import { stripIdAndTypename } from '../../utils/types'
 import OfferStatusSwitcher from './OfferStatusSwitcher'
 import PalletsEditor from './PalletsEditor'
 
@@ -46,7 +46,7 @@ const ViewOfferPage: FunctionComponent = () => {
     const updatedOffer: OfferUpdateInput = {
       id: offer.offer.id,
       status: newStatus,
-      contact: _omit(offer.offer.contact, ['__typename']),
+      contact: stripIdAndTypename(offer.offer.contact),
       photoUris: offer.offer.photoUris,
     }
 

--- a/frontend/src/pages/offers/addOfferMutation.graphql
+++ b/frontend/src/pages/offers/addOfferMutation.graphql
@@ -1,6 +1,0 @@
-mutation CreateOffer($input: OfferCreateInput!) {
-  addOffer(input: $input) {
-    id
-    shipmentId
-  }
-}

--- a/frontend/src/pages/offers/offerMutations.graphql
+++ b/frontend/src/pages/offers/offerMutations.graphql
@@ -1,0 +1,21 @@
+mutation CreateOffer($input: OfferCreateInput!) {
+  addOffer(input: $input) {
+    id
+    shipmentId
+  }
+}
+
+mutation UpdateOffer($input: OfferUpdateInput!) {
+  updateOffer(input: $input) {
+    id
+    status
+    contact {
+      name
+      email
+      phone
+      signal
+      whatsApp
+    }
+    photoUris
+  }
+}

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -6,6 +6,7 @@ import {
 } from '../data/constants'
 import {
   GroupType,
+  LineItem,
   LineItemCategory,
   LineItemContainerType,
   Maybe,
@@ -119,15 +120,21 @@ export function formatContainerType(type: LineItemContainerType) {
   }[type]
 }
 
-export function getLineItemVolume(lineItem: any) {
+export function getLineItemVolumeInSquareMeters(
+  lineItem: Pick<
+    LineItem,
+    'containerWidthCm' | 'containerHeightCm' | 'containerLengthCm'
+  >,
+) {
   const {
     containerWidthCm = 0,
     containerLengthCm = 0,
     containerHeightCm = 0,
   } = lineItem
+
   return (
     (
-      (containerHeightCm * containerLengthCm * containerWidthCm) /
+      (containerHeightCm! * containerLengthCm! * containerWidthCm!) /
       1000000
     ).toFixed(2) + 'm³'
   )

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -7,6 +7,7 @@ import {
 import {
   GroupType,
   LineItemCategory,
+  LineItemContainerType,
   Maybe,
   PalletType,
   Shipment,
@@ -107,4 +108,27 @@ export function formatShipmentName(
 ) {
   const month = shipment.labelMonth.toString().padStart(2, '0')
   return `${shipment.shippingRoute}-${shipment.labelYear}-${month}`
+}
+
+export function formatContainerType(type: LineItemContainerType) {
+  return {
+    [LineItemContainerType.Box]: 'Box',
+    [LineItemContainerType.BulkBag]: 'Bulk bag',
+    [LineItemContainerType.FullPallet]: 'Full pallet',
+    [LineItemContainerType.Unset]: 'Not set',
+  }[type]
+}
+
+export function getLineItemVolume(lineItem: any) {
+  const {
+    containerWidthCm = 0,
+    containerLengthCm = 0,
+    containerHeightCm = 0,
+  } = lineItem
+  return (
+    (
+      (containerHeightCm * containerLengthCm * containerWidthCm) /
+      1000000
+    ).toFixed(2) + 'm³'
+  )
 }

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -1,3 +1,5 @@
+import _omit from 'lodash/omit'
+
 /**
  * Returns an array with all the keys in an enum
  * @example
@@ -28,4 +30,13 @@ export function enumValues<O extends object, K extends keyof O = keyof O>(
   obj: O,
 ): K[] {
   return Object.values(obj) as K[]
+}
+
+/**
+ * Strips the `id` and `__typename` fields from an entity
+ */
+export const stripIdAndTypename = <T extends object>(
+  entity: T | null | undefined,
+) => {
+  return _omit(entity, ['id', '__typename']) as Omit<T, '__typename' | 'id'>
 }


### PR DESCRIPTION
### Changes

- allow users to change the status of offers. Admins can change the status at will, while group captains can only move an offer to "Proposed"
- added the calculated volume of each offer
- added a warning icon to offers that contain dangerous goods

### Screenshots

<img width="500" alt="Screen Shot 2021-04-28 at 10 21 39 AM" src="https://user-images.githubusercontent.com/3411183/116447850-46c09700-a80d-11eb-811c-2c2e16f2ac89.png">
<img width="500" alt="Screen Shot 2021-04-28 at 10 21 45 AM" src="https://user-images.githubusercontent.com/3411183/116447853-47592d80-a80d-11eb-8577-b08d18a50c6b.png">
<img width="353" alt="Screen Shot 2021-04-28 at 10 29 11 AM" src="https://user-images.githubusercontent.com/3411183/116447857-47f1c400-a80d-11eb-904d-1b1a6814511e.png">
