### PR TITLE
Set up the proper shipping routes and shipment restrictions

### DIFF
--- a/frontend/src/data/constants.ts
+++ b/frontend/src/data/constants.ts
@@ -6,6 +6,7 @@ import {
   OfferStatus,
   PalletType,
   PaymentStatus,
+  ShippingRoute,
 } from '../types/api-types'
 import { enumValues } from '../utils/types'
 
@@ -404,3 +405,59 @@ export const COUNTRY_CODE_OPTIONS = Object.entries(COUNTRY_CODES_TO_NAME).map(
     value: countryCode,
   }),
 )
+
+export const SENDING_REGIONS = [
+  { code: 'UK', label: 'United Kingdom' },
+  { code: 'DE', label: 'Germany' },
+]
+
+export const RECEIVING_REGIONS = [
+  { code: 'FR', label: 'France' },
+  { code: 'GR', label: 'Greece' },
+  { code: 'CS', label: 'Serbia' },
+  { code: 'BA', label: 'Bosnia' },
+  { code: 'LB', label: 'Lebanon' },
+]
+
+export const SHIPPING_ROUTE_OPTIONS = [
+  {
+    value: ShippingRoute.DeToBa,
+    label: 'Germany to Bosnia',
+  },
+  {
+    value: ShippingRoute.DeToCs,
+    label: 'Germany to Serbia',
+  },
+  {
+    value: ShippingRoute.DeToFr,
+    label: 'Germany to France',
+  },
+  {
+    value: ShippingRoute.DeToGr,
+    label: 'Germany to Greece',
+  },
+  {
+    value: ShippingRoute.DeToLb,
+    label: 'Germany to Lebanon',
+  },
+  {
+    value: ShippingRoute.UkToBa,
+    label: 'UK to Bosnia',
+  },
+  {
+    value: ShippingRoute.UkToCs,
+    label: 'UK to Serbia',
+  },
+  {
+    value: ShippingRoute.UkToFr,
+    label: 'UK to France',
+  },
+  {
+    value: ShippingRoute.UkToGr,
+    label: 'UK to Greece',
+  },
+  {
+    value: ShippingRoute.UkToLb,
+    label: 'UK to Lebanon',
+  },
+]

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -8,9 +8,12 @@ import LayoutWithNav from '../layouts/LayoutWithNav'
 const AdminPage: FunctionComponent = () => {
   return (
     <LayoutWithNav>
-      <div className="text-navy-800 flex flex-col space-y-2">
-        <Link to="/groups">Groups</Link>
-        <Link to="/users">Users (in construction)</Link>
+      <div className="bg-white max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content">
+        <h1 className="text-navy-800 text-3xl mb-2">Admin</h1>
+        <div className="text-navy-800 flex flex-col space-y-2">
+          <Link to="/groups">Groups</Link>
+          <Link to="/users">Users (in construction)</Link>
+        </div>
       </div>
     </LayoutWithNav>
   )

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent } from 'react'
 import { Link } from 'react-router-dom'
+import CogIcon from '../components/icons/CogIcon'
 import LayoutWithNav from '../layouts/LayoutWithNav'
 
 /**
@@ -9,11 +10,18 @@ const AdminPage: FunctionComponent = () => {
   return (
     <LayoutWithNav>
       <div className="bg-white max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content">
-        <h1 className="text-navy-800 text-3xl mb-2">Admin</h1>
-        <div className="text-navy-800 flex flex-col space-y-2">
-          <Link to="/groups">Groups</Link>
-          <Link to="/users">Users (in construction)</Link>
-        </div>
+        <header className="p-6 border-b border-gray-200 md:flex items-center justify-between">
+          <h1 className="text-navy-800 text-3xl mb-4 md:mb-0">Admin</h1>
+        </header>
+        <main className="p-4">
+          <div className="text-navy-800 flex flex-col space-y-2">
+            <Link to="/groups" className="flex items-center hover:underline">
+              <CogIcon className="w-5 h-5 mr-1" />
+              Manage groups
+            </Link>
+            <Link to="/users">Users (in construction)</Link>
+          </div>
+        </main>
       </div>
     </LayoutWithNav>
   )

--- a/frontend/src/pages/groups/GroupCreatePage.tsx
+++ b/frontend/src/pages/groups/GroupCreatePage.tsx
@@ -46,7 +46,7 @@ const GroupCreatePage: FunctionComponent = () => {
 
   return (
     <LayoutWithNav>
-      <div className="max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content">
+      <div className="bg-white max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content">
         <header className="p-4 md:p-6 border-b border-gray-200">
           <h1 className="text-navy-800 text-3xl mb-2">New group</h1>
           <p className="text-gray-700">

--- a/frontend/src/pages/shipments/ShipmentCreatePage.tsx
+++ b/frontend/src/pages/shipments/ShipmentCreatePage.tsx
@@ -35,7 +35,7 @@ const ShipmentCreatePage: FunctionComponent = () => {
 
   return (
     <LayoutWithNav>
-      <div className="max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content">
+      <div className="bg-white max-w-5xl mx-auto border-l border-r border-gray-200 min-h-content">
         <header className="p-4 md:p-6 border-b border-gray-200">
           <h1 className="text-navy-800 text-3xl mb-2">New shipment</h1>
           <p className="text-gray-700 max-w-xl">

--- a/frontend/src/pages/shipments/ShipmentDetails.tsx
+++ b/frontend/src/pages/shipments/ShipmentDetails.tsx
@@ -6,6 +6,7 @@ import { useShipmentQuery } from '../../types/api-types'
 import {
   formatCountryCodeToName,
   formatLabelMonth,
+  formatShippingRouteName,
   getShipmentStatusBadgeColor,
 } from '../../utils/format'
 
@@ -44,8 +45,8 @@ const ShipmentDetails: FunctionComponent<Props> = ({ shipmentId }) => {
       <h2 className="font-semibold mt-6 mb-4">Itinerary</h2>
       <p className="text-gray-600 mb-4">
         This shipment follows the{' '}
-        <span className="text-semibold text-gray-800">
-          {shipmentData.shippingRoute}
+        <span className="font-semibold text-gray-800">
+          {formatShippingRouteName(shipmentData.shippingRoute)}
         </span>{' '}
         route.
       </p>

--- a/frontend/src/pages/shipments/ShipmentList.tsx
+++ b/frontend/src/pages/shipments/ShipmentList.tsx
@@ -10,6 +10,7 @@ import { AllShipmentsQuery, useAllShipmentsQuery } from '../../types/api-types'
 import {
   formatLabelMonth,
   formatShipmentName,
+  formatShippingRouteName,
   getShipmentStatusBadgeColor,
 } from '../../utils/format'
 import ROUTES, { shipmentViewRoute } from '../../utils/routes'
@@ -21,7 +22,7 @@ const COLUMNS: Column<AllShipmentsQuery['listShipments'][0]>[] = [
   },
   {
     Header: 'Route',
-    accessor: 'shippingRoute',
+    accessor: (row) => formatShippingRouteName(row.shippingRoute),
   },
   {
     Header: 'Sending hub',
@@ -46,7 +47,7 @@ const COLUMNS: Column<AllShipmentsQuery['listShipments'][0]>[] = [
 ]
 
 const ShipmentList: FunctionComponent = () => {
-  const { data } = useAllShipmentsQuery()
+  const { data, error } = useAllShipmentsQuery()
 
   // We must memoize the data for react-table to function properly
   const shipments = useMemo(() => data?.listShipments || [], [data])
@@ -67,6 +68,12 @@ const ShipmentList: FunctionComponent = () => {
           <ButtonLink to={ROUTES.SHIPMENT_CREATE}>Create shipment</ButtonLink>
         </header>
         <main className="pb-20 overflow-x-auto">
+          {error && (
+            <div className="p-4 rounded bg-red-50 mb-6 text-red-800">
+              <p className="font-semibold">Error:</p>
+              <p>{error.message}</p>
+            </div>
+          )}
           <table className="w-full whitespace-nowrap" {...getTableProps()}>
             <thead className="border-b border-gray-200">
               {headerGroups.map((headerGroup) => (

--- a/frontend/src/pages/shipments/allShipmentFieldsFragment.graphql
+++ b/frontend/src/pages/shipments/allShipmentFieldsFragment.graphql
@@ -5,6 +5,8 @@ fragment AllShipmentFields on Shipment {
   labelMonth
   offerSubmissionDeadline
   status
+  receivingHubId
+  sendingHubId
   receivingHub {
     id
     name

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -101,7 +101,7 @@ export function getShipmentStatusBadgeColor(
  * unique identifier!
  * @param shipment
  * @returns A non-unique identifier for the shipment
- * @example "UK-2021-03"
+ * @example formatShipmentName(shipment) // "UK-FR-2021-03"
  */
 export function formatShipmentName(
   shipment:

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -4,6 +4,7 @@ import {
   COUNTRY_CODES_TO_NAME,
   LINE_ITEM_CATEGORY_OPTIONS,
   MONTHS,
+  SHIPPING_ROUTE_OPTIONS,
 } from '../data/constants'
 import {
   AllGroupsMinimalQuery,
@@ -16,6 +17,7 @@ import {
   Shipment,
   ShipmentQuery,
   ShipmentStatus,
+  ShippingRoute,
 } from '../types/api-types'
 
 export function formatGroupType(type: GroupType) {
@@ -110,7 +112,16 @@ export function formatShipmentName(
       >,
 ) {
   const month = shipment.labelMonth.toString().padStart(2, '0')
-  return `${shipment.shippingRoute}-${shipment.labelYear}-${month}`
+  return `${shipment.shippingRoute.toString().replace('_TO_', '-')}-${
+    shipment.labelYear
+  }-${month}`
+}
+
+export function formatShippingRouteName(shippingRoute: ShippingRoute) {
+  const matchingRoute = SHIPPING_ROUTE_OPTIONS.find(
+    (option) => option.value === shippingRoute,
+  )
+  return matchingRoute?.label || 'Unknown route'
 }
 
 export function formatContainerType(

--- a/schema.graphql
+++ b/schema.graphql
@@ -120,7 +120,16 @@ input ShipmentCreateInput {
 }
 
 enum ShippingRoute {
-  UK
+  UK_TO_FR
+  UK_TO_GR
+  UK_TO_CS
+  UK_TO_BA
+  UK_TO_LB
+  DE_TO_FR
+  DE_TO_GR
+  DE_TO_CS
+  DE_TO_BA
+  DE_TO_LB
 }
 
 enum ShipmentStatus {

--- a/src/tests/line_items_api.test.ts
+++ b/src/tests/line_items_api.test.ts
@@ -55,7 +55,7 @@ describe('LineItems API', () => {
     })
 
     shipment = await Shipment.create({
-      shippingRoute: ShippingRoute.Uk,
+      shippingRoute: ShippingRoute.UkToBa,
       labelYear: 2020,
       labelMonth: 1,
       sendingHubId: group.id,

--- a/src/tests/offers_api.test.ts
+++ b/src/tests/offers_api.test.ts
@@ -65,7 +65,7 @@ describe('Offers API', () => {
       },
     })
     shipment = await createShipment({
-      shippingRoute: ShippingRoute.Uk,
+      shippingRoute: ShippingRoute.UkToGr,
       labelYear: 2020,
       labelMonth: 1,
       sendingHubId: captainsGroup.id,
@@ -360,7 +360,7 @@ describe('Offers API', () => {
       otherShipment = await createShipment({
         labelYear: 2021,
         labelMonth: 1,
-        shippingRoute: ShippingRoute.Uk,
+        shippingRoute: ShippingRoute.UkToFr,
         sendingHubId: captainsGroup.id,
         receivingHubId: captainsGroup.id,
         status: ShipmentStatus.Open,

--- a/src/tests/pallets_api.test.ts
+++ b/src/tests/pallets_api.test.ts
@@ -59,7 +59,7 @@ describe('Pallets API', () => {
     })
 
     shipment = await Shipment.create({
-      shippingRoute: ShippingRoute.Uk,
+      shippingRoute: ShippingRoute.UkToCs,
       labelYear: 2020,
       labelMonth: 1,
       sendingHubId: group.id,

--- a/src/tests/shipment_exports_api.test.ts
+++ b/src/tests/shipment_exports_api.test.ts
@@ -53,7 +53,7 @@ describe('ShipmentExports API', () => {
     })
 
     shipment = await Shipment.create({
-      shippingRoute: ShippingRoute.Uk,
+      shippingRoute: ShippingRoute.UkToCs,
       labelYear: 2020,
       labelMonth: 1,
       sendingHubId: group.id,

--- a/src/tests/shipments_api.test.ts
+++ b/src/tests/shipments_api.test.ts
@@ -73,7 +73,7 @@ describe('Shipments API', () => {
         mutation: ADD_SHIPMENT,
         variables: {
           input: {
-            shippingRoute: ShippingRoute.Uk,
+            shippingRoute: ShippingRoute.UkToFr,
             labelYear: nextYear,
             labelMonth: 1,
             sendingHubId: group1.id,
@@ -103,7 +103,7 @@ describe('Shipments API', () => {
         mutation: ADD_SHIPMENT,
         variables: {
           input: {
-            shippingRoute: ShippingRoute.Uk,
+            shippingRoute: ShippingRoute.UkToFr,
             labelYear: nextYear,
             labelMonth: 1,
             sendingHubId: group1.id,
@@ -114,7 +114,9 @@ describe('Shipments API', () => {
       })
 
       expect(res.errors).toBeUndefined()
-      expect(res?.data?.addShipment?.shippingRoute).toEqual(ShippingRoute.Uk)
+      expect(res?.data?.addShipment?.shippingRoute).toEqual(
+        ShippingRoute.UkToFr,
+      )
       expect(res?.data?.addShipment?.labelYear).toEqual(nextYear)
       expect(res?.data?.addShipment?.labelMonth).toEqual(1)
       expect(res?.data?.addShipment?.sendingHubId).toEqual(group1.id)
@@ -143,7 +145,7 @@ describe('Shipments API', () => {
 
     beforeEach(async () => {
       shipment = await createShipment({
-        shippingRoute: ShippingRoute.Uk,
+        shippingRoute: ShippingRoute.UkToFr,
         labelYear: nextYear,
         labelMonth: 1,
         sendingHubId: group1.id,
@@ -277,7 +279,7 @@ describe('Shipments API', () => {
   describe('listShipments', () => {
     it('lists existing shipments', async () => {
       const shipment1 = await createShipment({
-        shippingRoute: ShippingRoute.Uk,
+        shippingRoute: ShippingRoute.UkToFr,
         labelYear: nextYear,
         labelMonth: 1,
         sendingHubId: group1.id,
@@ -286,7 +288,7 @@ describe('Shipments API', () => {
       })
 
       const shipment2 = await createShipment({
-        shippingRoute: ShippingRoute.Uk,
+        shippingRoute: ShippingRoute.UkToFr,
         labelYear: nextYear + 1,
         labelMonth: 6,
         sendingHubId: group2.id,
@@ -350,7 +352,7 @@ describe('Shipments API', () => {
 
     beforeEach(async () => {
       shipment = await createShipment({
-        shippingRoute: ShippingRoute.Uk,
+        shippingRoute: ShippingRoute.UkToFr,
         labelYear: nextYear,
         labelMonth: 1,
         sendingHubId: group1.id,


### PR DESCRIPTION
### Changes

- restricted the `sendingHub` and `receivingHub` fields on Shipments to `GroupType.DA_HUB`
- added all the shipping routes and regions into the system

### Pixels

List of shipping routes:

<img width="500" alt="Screen Shot 2021-05-20 at 10 17 29 AM" src="https://user-images.githubusercontent.com/3411183/119021738-a0bc0480-b954-11eb-8eb7-6b43b2a3b6bb.png">

The shipment view:

<img width="500" alt="Screen Shot 2021-05-20 at 10 06 37 AM" src="https://user-images.githubusercontent.com/3411183/119020612-4a9a9180-b953-11eb-97cd-058f10da7543.png">

The list of shipments view:

<img width="500" alt="Screen Shot 2021-05-20 at 10 01 39 AM" src="https://user-images.githubusercontent.com/3411183/119020642-55edbd00-b953-11eb-9132-c26a709aa740.png">
