### PR TITLE
feat: add input validation for adding a group

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,12 @@
   "author": "Distribute Aid",
   "license": "(ISC OR GPL-3.0)",
   "dependencies": {
+    "@sinclair/typebox": "^0.16.7",
     "@types/body-scroll-lock": "^2.6.1",
     "@types/graphql-depth-limit": "^1.1.2",
     "@types/lodash": "^4.14.168",
+    "ajv": "^8.5.0",
+    "ajv-formats": "^2.1.0",
     "apollo-server": "^2.21.0",
     "apollo-server-express": "^2.21.0",
     "body-scroll-lock": "^3.1.5",

--- a/src/resolvers/validateWithJSONSchema.ts
+++ b/src/resolvers/validateWithJSONSchema.ts
@@ -26,11 +26,14 @@ export const validateWithJSONSchema = <T extends TObject<TProperties>>(
       value: Static<typeof schema>
     }) => {
   const v = ajv.compile(schema)
+
   return (value: Record<string, any>) => {
     const valid = v(value)
+
     if (valid !== true) {
       return { errors: v.errors as ErrorObject[] }
     }
+
     return { value: value as Static<typeof schema> }
   }
 }

--- a/src/resolvers/validateWithJSONSchema.ts
+++ b/src/resolvers/validateWithJSONSchema.ts
@@ -1,0 +1,36 @@
+import { Static, TObject, TProperties } from '@sinclair/typebox'
+import Ajv, { ErrorObject } from 'ajv'
+import addFormats from 'ajv-formats'
+
+const ajv = addFormats(new Ajv(), [
+  'date-time',
+  'time',
+  'date',
+  'email',
+  'uri',
+  'uuid',
+])
+// see https://github.com/sinclairzx81/typebox/issues/51
+ajv.addKeyword('kind')
+ajv.addKeyword('modifier')
+
+export const validateWithJSONSchema = <T extends TObject<TProperties>>(
+  schema: T,
+): ((
+  value: Record<string, any>,
+) =>
+  | {
+      errors: ErrorObject[]
+    }
+  | {
+      value: Static<typeof schema>
+    }) => {
+  const v = ajv.compile(schema)
+  return (value: Record<string, any>) => {
+    const valid = v(value)
+    if (valid !== true) {
+      return { errors: v.errors as ErrorObject[] }
+    }
+    return { value: value as Static<typeof schema> }
+  }
+}

--- a/src/tests/validateWithJSONSchema.test.ts
+++ b/src/tests/validateWithJSONSchema.test.ts
@@ -14,6 +14,7 @@ describe('validateWithJSONSchema', () => {
       errors: undefined,
     })
   })
+
   it('should return errors if input does not match the JSON schema', () => {
     expect(
       validateWithJSONSchema(

--- a/src/tests/validateWithJSONSchema.test.ts
+++ b/src/tests/validateWithJSONSchema.test.ts
@@ -1,0 +1,39 @@
+import { Type } from '@sinclair/typebox'
+import { validateWithJSONSchema } from '../resolvers/validateWithJSONSchema'
+
+describe('validateWithJSONSchema', () => {
+  it('should validate input against a JSON schema', () => {
+    expect(
+      validateWithJSONSchema(
+        Type.Object({
+          foo: Type.String({ minLength: 1 }),
+        }),
+      )({ foo: 'bar' }),
+    ).toEqual({
+      value: { foo: 'bar' },
+      errors: undefined,
+    })
+  })
+  it('should return errors if input does not match the JSON schema', () => {
+    expect(
+      validateWithJSONSchema(
+        Type.Object({
+          foo: Type.String({ minLength: 1 }),
+        }),
+      )({ bar: 'baz' }),
+    ).toEqual({
+      value: undefined,
+      errors: [
+        {
+          instancePath: '',
+          keyword: 'required',
+          message: "must have required property 'foo'",
+          params: {
+            missingProperty: 'foo',
+          },
+          schemaPath: '#/required',
+        },
+      ],
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1412,6 +1412,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sinclair/typebox@^0.16.7":
+  version "0.16.7"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.16.7.tgz#3187369b2ff237f57477ef155be4c992e592fa7c"
+  integrity sha512-d12AkLZJXD30hXBhJSgf33RqGO0NMHIDzsQPYfp6WGoaSuMnSGIUanII2OUbeZFnD/j3Nbl2zifgO2+5tPClCQ==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz"
@@ -1945,6 +1950,13 @@ agent-base@6:
   dependencies:
     debug "4"
 
+ajv-formats@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.0.tgz#96eaf83e38d32108b66d82a9cb0cfa24886cdfeb"
+  integrity sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.12.3, ajv@^6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz"
@@ -1953,6 +1965,16 @@ ajv@^6.12.3, ajv@^6.12.6:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.5.0.tgz#695528274bcb5afc865446aa275484049a18ae4b"
+  integrity sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ansi-align@^3.0.0:
@@ -5625,6 +5647,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -7388,6 +7415,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 require-main-filename@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This adds input validation to the addGroup mutation,
using typebox to define a JSON schema, and Ajv to
validate the input against the schema.

This PR serves as a proof of concept for the validation
mechanics to be introduced into the project.

See #47.

A *valid* GQL query:

```gql
mutation addGroup {
  addGroup(
    input: {
      name: ""
      groupType: SENDING_GROUP
      primaryLocation: { countryCode: "DE", townCity: "" }
      primaryContact: { name: "" }
    }
  ) {
    id
  }
}
```

Now returns this error:

```json
{
  "errors": [
    {
      "message": "Group arguments invalid",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "addGroup"
      ],
      "extensions": {
        "0": {
          "instancePath": "/name",
          "schemaPath": "#/properties/name/minLength",
          "keyword": "minLength",
          "params": {
            "limit": 1
          },
          "message": "must NOT have fewer than 1 characters"
        },
        "code": "BAD_USER_INPUT",
        "exception": {
          "0": {
            "instancePath": "/name",
            "schemaPath": "#/properties/name/minLength",
            "keyword": "minLength",
            "params": {
              "limit": 1
            },
            "message": "must NOT have fewer than 1 characters"
          },
          "stacktrace": [
            "UserInputError: Group arguments invalid",
            "    at /workspaces/shipment-tracker/src/resolvers/group.ts:76:11",
            "    at Generator.next (<anonymous>)",
            "    at /workspaces/shipment-tracker/src/resolvers/group.ts:8:71",
            "    at new Promise (<anonymous>)",
            "    at __awaiter (/workspaces/shipment-tracker/src/resolvers/group.ts:4:12)",
            "    at addGroup (/workspaces/shipment-tracker/src/resolvers/group.ts:73:5)",
            "    at field.resolve (/workspaces/shipment-tracker/node_modules/apollo-server-core/src/utils/schemaInstrumentation.ts:103:18)",
            "    at resolveField (/workspaces/shipment-tracker/node_modules/graphql/execution/execute.js:464:18)",
            "    at /workspaces/shipment-tracker/node_modules/graphql/execution/execute.js:261:18",
            "    at /workspaces/shipment-tracker/node_modules/graphql/jsutils/promiseReduce.js:23:10"
          ]
        }
      }
    }
  ],
  "data": null
}
```