### PR TITLE
Added 3 shipment statuses

### DIFF
--- a/frontend/src/components/TopNavigation.tsx
+++ b/frontend/src/components/TopNavigation.tsx
@@ -57,7 +57,7 @@ const TopNavigation: FunctionComponent<Props> = ({ hideControls }) => {
   )
 
   return (
-    <header className="py-2 bg-navy-800 h-nav sticky top-0">
+    <header className="py-2 bg-navy-800 h-nav sticky top-0 z-20">
       <div className="max-w-5xl px-4 mx-auto h-full flex items-center justify-between">
         <MobileNavigation navLinks={filteredNavLinks} />
         <div className="flex items-center">

--- a/frontend/src/data/constants.ts
+++ b/frontend/src/data/constants.ts
@@ -46,13 +46,23 @@ export const OFFER_STATUS_OPTIONS = enumValues(OfferStatus).map((routeKey) => ({
   value: routeKey,
 }))
 
+/**
+ * Order of shipment statuses:
+ * draft → announced → open to offers → aid matching → staging at a hub
+ * → in transit → complete
+ *
+ * A shipment can also be 'abandoned' or 'archived' at any point.
+ */
 export const SHIPMENT_STATUS_OPTIONS = [
-  { label: 'Abandoned', value: ShipmentStatus.Abandoned },
+  { label: 'Draft', value: ShipmentStatus.Draft },
   { label: 'Announced', value: ShipmentStatus.Announced },
+  { label: 'Open to offers', value: ShipmentStatus.Open },
+  { label: 'Aid matching', value: ShipmentStatus.AidMatching },
+  { label: 'Staging at a hub', value: ShipmentStatus.Staging },
+  { label: 'In transit', value: ShipmentStatus.InProgress },
   { label: 'Complete', value: ShipmentStatus.Complete },
-  { label: 'In progress', value: ShipmentStatus.InProgress },
-  { label: 'Open', value: ShipmentStatus.Open },
-  { label: 'In staging', value: ShipmentStatus.Staging },
+  { label: 'Abandoned', value: ShipmentStatus.Abandoned },
+  { label: 'Archived', value: ShipmentStatus.Archived },
 ] as const
 
 export const PALLET_PAYMENT_STATUS_OPTIONS = [

--- a/frontend/src/pages/shipments/ShipmentCreatePage.tsx
+++ b/frontend/src/pages/shipments/ShipmentCreatePage.tsx
@@ -4,6 +4,7 @@ import LayoutWithNav from '../../layouts/LayoutWithNav'
 import {
   AllShipmentsDocument,
   ShipmentCreateInput,
+  ShipmentStatus,
   useCreateShipmentMutation,
 } from '../../types/api-types'
 import { shipmentViewRoute } from '../../utils/routes'
@@ -19,6 +20,8 @@ const ShipmentCreatePage: FunctionComponent = () => {
 
   const onSubmit = (input: ShipmentCreateInput) => {
     // Create the shipment and then redirect to its "view" page
+    input.status = ShipmentStatus.Draft
+
     addShipment({
       variables: { input },
       // Fetch the updated list of shipments

--- a/frontend/src/pages/shipments/ShipmentDetails.tsx
+++ b/frontend/src/pages/shipments/ShipmentDetails.tsx
@@ -6,6 +6,7 @@ import { useShipmentQuery } from '../../types/api-types'
 import {
   formatCountryCodeToName,
   formatLabelMonth,
+  formatShipmentStatus,
   formatShippingRouteName,
   getShipmentStatusBadgeColor,
 } from '../../utils/format'
@@ -38,7 +39,7 @@ const ShipmentDetails: FunctionComponent<Props> = ({ shipmentId }) => {
         </ReadOnlyField>
         <ReadOnlyField label="Status">
           <Badge color={getShipmentStatusBadgeColor(shipmentData.status)}>
-            {shipmentData.status}
+            {formatShipmentStatus(shipmentData.status)}
           </Badge>
         </ReadOnlyField>
       </div>

--- a/frontend/src/pages/shipments/ShipmentForm.tsx
+++ b/frontend/src/pages/shipments/ShipmentForm.tsx
@@ -3,12 +3,15 @@ import { FunctionComponent, ReactNode, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import Button from '../../components/Button'
 import SelectField, { SelectOption } from '../../components/forms/SelectField'
-import { MONTH_OPTIONS, SHIPPING_ROUTE_OPTIONS } from '../../data/constants'
+import {
+  MONTH_OPTIONS,
+  SHIPMENT_STATUS_OPTIONS,
+  SHIPPING_ROUTE_OPTIONS,
+} from '../../data/constants'
 import {
   GroupType,
   ShipmentCreateInput,
   ShipmentQuery,
-  ShipmentStatus,
   useAllGroupsMinimalQuery,
 } from '../../types/api-types'
 import { groupToSelectOption } from '../../utils/format'
@@ -38,15 +41,6 @@ interface Props {
   showSaveConfirmation?: boolean
 }
 
-const STATUS_OPTIONS = [
-  { label: 'Announced', value: ShipmentStatus.Announced },
-  { label: 'In progress', value: ShipmentStatus.InProgress },
-  { label: 'Open', value: ShipmentStatus.Open },
-  { label: 'In staging', value: ShipmentStatus.Staging },
-  { label: 'Complete', value: ShipmentStatus.Complete },
-  { label: 'Abandoned', value: ShipmentStatus.Abandoned },
-]
-
 const YEAR_OPTIONS = _range(
   new Date().getFullYear(),
   new Date().getFullYear() + 5,
@@ -56,6 +50,7 @@ const DEFAULT_MONTH = (new Date().getMonth() + 2) % 12
 
 const ShipmentForm: FunctionComponent<Props> = (props) => {
   const [hubs, setHubs] = useState<SelectOption[]>([])
+  const [isExistingShipment, setIsExistingShipment] = useState(false)
 
   // Load the list of groups
   const { data: groups, loading: hubListIsLoading } = useAllGroupsMinimalQuery()
@@ -89,6 +84,7 @@ const ShipmentForm: FunctionComponent<Props> = (props) => {
     function resetFormValues() {
       if (props.defaultValues) {
         reset(props.defaultValues.shipment)
+        setIsExistingShipment(props.defaultValues.shipment.id != null)
       }
     },
     [props.defaultValues, reset],
@@ -132,15 +128,16 @@ const ShipmentForm: FunctionComponent<Props> = (props) => {
 
   return (
     <form onSubmit={handleSubmit(props.onSubmit)} className="space-y-6">
-      <SelectField
-        defaultValue={ShipmentStatus.Announced}
-        options={STATUS_OPTIONS}
-        label="Status"
-        name="status"
-        register={register}
-        required
-        errors={errors}
-      />
+      {isExistingShipment && (
+        <SelectField
+          options={SHIPMENT_STATUS_OPTIONS}
+          label="Status"
+          name="status"
+          register={register}
+          required
+          errors={errors}
+        />
+      )}
       <SelectField
         options={SHIPPING_ROUTE_OPTIONS}
         label="Shipping route"

--- a/frontend/src/pages/shipments/ShipmentList.tsx
+++ b/frontend/src/pages/shipments/ShipmentList.tsx
@@ -17,6 +17,7 @@ import {
 import {
   formatLabelMonth,
   formatShipmentName,
+  formatShipmentStatus,
   formatShippingRouteName,
   getShipmentStatusBadgeColor,
 } from '../../utils/format'
@@ -48,7 +49,9 @@ const COLUMNS: Column<AllShipmentsQuery['listShipments'][0]>[] = [
     Header: 'Status',
     accessor: 'status',
     Cell: ({ value }: any) => (
-      <Badge color={getShipmentStatusBadgeColor(value)}>{value}</Badge>
+      <Badge color={getShipmentStatusBadgeColor(value)}>
+        {formatShipmentStatus(value)}
+      </Badge>
     ),
   },
 ]

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -4,6 +4,7 @@ import {
   COUNTRY_CODES_TO_NAME,
   LINE_ITEM_CATEGORY_OPTIONS,
   MONTHS,
+  SHIPMENT_STATUS_OPTIONS,
   SHIPPING_ROUTE_OPTIONS,
 } from '../data/constants'
 import {
@@ -80,17 +81,12 @@ export function getShipmentStatusBadgeColor(
   status: ShipmentStatus,
 ): BadgeColor {
   switch (status) {
-    case ShipmentStatus.Abandoned:
-      return 'red'
     case ShipmentStatus.Announced:
       return 'blue'
-    case ShipmentStatus.Complete:
-      return 'green'
-    case ShipmentStatus.InProgress:
-      return 'blue'
     case ShipmentStatus.Open:
-      return 'yellow'
-    case ShipmentStatus.Staging:
+      return 'green'
+    case ShipmentStatus.Abandoned:
+      return 'red'
     default:
       return 'gray'
   }
@@ -122,6 +118,13 @@ export function formatShippingRouteName(shippingRoute: ShippingRoute) {
     (option) => option.value === shippingRoute,
   )
   return matchingRoute?.label || 'Unknown route'
+}
+
+export function formatShipmentStatus(shipmentStatus: ShipmentStatus) {
+  const matchingStatus = SHIPMENT_STATUS_OPTIONS.find(
+    (option) => option.value === shipmentStatus,
+  )
+  return matchingStatus?.label || shipmentStatus
 }
 
 export function formatContainerType(

--- a/schema.graphql
+++ b/schema.graphql
@@ -133,12 +133,15 @@ enum ShippingRoute {
 }
 
 enum ShipmentStatus {
+  DRAFT
   ANNOUNCED
   OPEN
+  AID_MATCHING
   STAGING
   IN_PROGRESS
   COMPLETE
   ABANDONED
+  ARCHIVED
 }
 
 type Shipment {


### PR DESCRIPTION
### Changes

Added some shipment statuses:

```diff
 enum ShipmentStatus {
+  DRAFT
   ANNOUNCED
   OPEN
+  AID_MATCHING
   STAGING
   IN_PROGRESS
   COMPLETE
   ABANDONED
+  ARCHIVED
 }
```

### Screenshot

I formatted the statuses so things look a little nicer and less YELLY

<img width="1063" alt="Screen Shot 2021-06-23 at 5 18 09 PM" src="https://user-images.githubusercontent.com/3411183/123184684-08c8a380-d449-11eb-8e27-089d19c55fab.png">


