### PR TITLE
Fix the logic of the offer creation page

### DIFF
--- a/docs/psql.md
+++ b/docs/psql.md
@@ -1,0 +1,40 @@
+# How to interact with our database
+
+## Tricky things
+
+Psql ignore capitalization BUT it is case-sensitive. Silly, I know.
+
+```shell
+select * from groups; # Select everything from the "groups" table
+select * from Groups; # psql will lowercase "Groups" to "groups", which will fail!
+select * from "Groups"; # This will work as intended
+```
+
+Psql uses double quotes `"` for identifiers like a table or column name, but
+single quotes `'` for string literals.
+
+## Connecting to the Shipment Tracker db
+
+```shell
+# The local DB is called "distributeaid_dev"
+psql distributeaid_dev
+
+# Show the tables available
+\\dt
+
+# To show all the entries in the Groups table:
+select * from "Groups"; # Note the quotes around "Group" to preserve capitalization
+
+# Or select only the attributes you care about:
+select id, name from "Groups";
+
+# To select nested JSON fields, it gets tricky. Note the use of single and double quotes
+select "primaryContact" -> 'name' as contact from "Groups";
+
+```
+
+Commands in no particular order:
+
+```shell
+psql --list # List the available databases
+```

--- a/frontend/src/pages/groups/allGroupsQuery.graphql
+++ b/frontend/src/pages/groups/allGroupsQuery.graphql
@@ -1,5 +1,5 @@
-query AllGroups {
-  listGroups {
+query AllGroups($captainId: Int, $groupType: [GroupType!]) {
+  listGroups(captainId: $captainId, groupType: $groupType) {
     id
     name
     groupType

--- a/src/resolvers/offer.ts
+++ b/src/resolvers/offer.ts
@@ -56,7 +56,10 @@ const addOffer: MutationResolvers['addOffer'] = async (
   })
 
   const sendingGroup = await sendingGroupPromise
-  if (sendingGroup?.captainId !== context.auth.userAccount.id) {
+  if (
+    sendingGroup?.captainId !== context.auth.userAccount.id &&
+    !context.auth.isAdmin
+  ) {
     throw new ForbiddenError(
       `User ${context.auth.userAccount.id} not permitted to create offer for group ${valid.value.sendingGroupId}`,
     )


### PR DESCRIPTION
This PR addresses 2 problem:
- the fact that some users have access to multiple groups (ie admins) and should thus be allowed to create offers on any of those groups
- bug #230 where the contact info doesn't fill out automatically and prevents users from creating offers

Fixes #230.

