### PR TITLE
Filter the list of shipments for group captains

### DIFF
--- a/src/tests/shipments_api.test.ts
+++ b/src/tests/shipments_api.test.ts
@@ -335,18 +335,7 @@ describe('Shipments API', () => {
             name: group2.name,
           },
         },
-        {
-          id: shipment2.id,
-          status: shipment2.status,
-          sendingHub: {
-            id: group2.id,
-            name: group2.name,
-          },
-          receivingHub: {
-            id: group1.id,
-            name: group1.name,
-          },
-        },
+        // Shipment 2 will be filtered out because of its status
       ])
     })
 


### PR DESCRIPTION
Limits which shipments group captains can see in the list. Resolves #130.

Note: I originally assumed it'd be easier to do this on the client, but it was much cleaner to do it on the backend 😅 