### PR TITLE
Add guard against user id not being present

### DIFF
--- a/src/resolvers/group.ts
+++ b/src/resolvers/group.ts
@@ -1,5 +1,6 @@
 import { Type } from '@sinclair/typebox'
 import { ApolloError, ForbiddenError, UserInputError } from 'apollo-server'
+import { strict as assert } from 'assert'
 import { FindOptions, Op } from 'sequelize'
 import Group, { GroupAttributes } from '../models/group'
 import UserAccount from '../models/user_account'
@@ -93,6 +94,10 @@ const addGroup: MutationResolvers['addGroup'] = async (
   { input },
   context,
 ) => {
+  assert.ok(
+    typeof context.auth.userAccount.id === 'number',
+    'Current user id should be set',
+  )
   const valid = validateAddGroupInput(input)
   if ('errors' in valid) {
     throw new UserInputError('Group arguments invalid', valid.errors)
@@ -144,6 +149,10 @@ const updateGroup: MutationResolvers['updateGroup'] = async (
   { id, input },
   context,
 ) => {
+  assert.ok(
+    typeof context.auth.userAccount.id === 'number',
+    'Current user id should be set',
+  )
   const valid = validateUpdateGroupInput(input)
   if ('errors' in valid) {
     throw new UserInputError('Update group arguments invalid', valid.errors)

--- a/src/resolvers/offer.ts
+++ b/src/resolvers/offer.ts
@@ -1,5 +1,6 @@
 import { Type } from '@sinclair/typebox'
 import { ForbiddenError, UserInputError } from 'apollo-server'
+import { strict as assert } from 'assert'
 import Group from '../models/group'
 import Offer, { OfferAttributes } from '../models/offer'
 import Pallet from '../models/pallet'
@@ -41,6 +42,10 @@ const addOffer: MutationResolvers['addOffer'] = async (
   { input },
   context,
 ) => {
+  assert.ok(
+    typeof context.auth.userAccount.id === 'number',
+    'Current user id should be set',
+  )
   const valid = validateAddOfferInput(input)
   if ('errors' in valid) {
     throw new UserInputError('Add offer arguments invalid', valid.errors)

--- a/src/resolvers/offer_authorization.ts
+++ b/src/resolvers/offer_authorization.ts
@@ -1,4 +1,5 @@
 import { ApolloError, ForbiddenError } from 'apollo-server-express'
+import { strict as assert } from 'assert'
 import { AuthenticatedContext } from '../apolloServer'
 import Offer from '../models/offer'
 import { OfferStatus, ShipmentStatus } from '../server-internal-types'
@@ -31,6 +32,10 @@ const assertAccountIsCaptainOrAdmin = (
   offer: Offer,
   context: AuthenticatedContext,
 ): void => {
+  assert.ok(
+    typeof context.auth.userAccount.id === 'number',
+    'Current user id should be set',
+  )
   if (
     offer.sendingGroup.captainId !== context.auth.userAccount.id &&
     !context.auth.isAdmin


### PR DESCRIPTION
While testing with the frontend, I discovered (#288) that when I log-in the ID of my user was null:

```javascript
UserAccount {
  dataValues: { id: null, auth0Id: '' },
  _previousDataValues: { auth0Id: undefined },
  _changed: Set(1) { 'auth0Id' },
  _options: { isNewRecord: true, _schema: null, _schemaDelimiter: '' },
  isNewRecord: true
}
```

That lead to bugs (e.g. a new group that I had created did not have a captain).

This adds a check for this problem. Since it can't be solved by the user (or the application), `assert` is used.