### PR TITLE
fix(frontend): make auth0 settings configurable

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -10,7 +10,12 @@ REACT_APP_GRAPHQL_URL="http://localhost:3000/graphql"
 # The URL where the client runs
 REACT_APP_CLIENT_URL="http://localhost:8080"
 
-# The audience used for authenticating with Auth0
+# Auth0 configuration
+## Tenant
+REACT_APP_AUTH0_DOMAIN="distributeaid.eu.auth0.com"
+## Client ID
+REACT_APP_AUTH0_CLIENT_ID="hfNo3Nw2ZrAGv0Vwh7tjU4nJ7lAuPTNH"
+## audience
 REACT_APP_AUTH0_AUDIENCE="https://da-shipping-tracker-dev"
 
 # See this issue https://github.com/facebook/create-react-app/issues/1795#issuecomment-357353472

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,8 +7,8 @@ import './stylesheets/index.output.css'
 ReactDOM.render(
   <React.StrictMode>
     <Auth0Provider
-      domain="distributeaid.eu.auth0.com"
-      clientId="hfNo3Nw2ZrAGv0Vwh7tjU4nJ7lAuPTNH"
+      domain={process.env.REACT_APP_AUTH0_DOMAIN as string}
+      clientId={process.env.REACT_APP_AUTH0_CLIENT_ID as string}
       redirectUri={window.location.origin}
       audience={process.env.REACT_APP_AUTH0_AUDIENCE}
     >


### PR DESCRIPTION
This will be needed for #268 because prod should use a separate
client (and maybe even tenant).