### PR TITLE
Remove sending receiving group type

### DIFF
--- a/db/migrations/000-initial.ts
+++ b/db/migrations/000-initial.ts
@@ -120,9 +120,7 @@ export const up = async (queryInterface: QueryInterface) => {
       type: DataTypes.STRING,
       allowNull: false,
       validate: {
-        isIn: [
-          [GroupType.DaHub, GroupType.ReceivingGroup, GroupType.SendingGroup],
-        ],
+        isIn: [[GroupType.Regular, GroupType.DaHub]],
       },
     },
     primaryLocation: {

--- a/frontend/src/data/constants.ts
+++ b/frontend/src/data/constants.ts
@@ -36,8 +36,7 @@ export const MONTH_OPTIONS = MONTHS.map((month, index) => ({
 }))
 
 export const GROUP_TYPE_OPTIONS = [
-  { label: 'Receiving group', value: GroupType.ReceivingGroup },
-  { label: 'Sending group', value: GroupType.SendingGroup },
+  { label: 'Regular group', value: GroupType.Regular },
   { label: 'DA hub', value: GroupType.DaHub },
 ]
 

--- a/frontend/src/pages/groups/GroupForm.tsx
+++ b/frontend/src/pages/groups/GroupForm.tsx
@@ -52,9 +52,9 @@ const GroupForm: FunctionComponent<Props> = (props) => {
   )
 
   const submitForm = handleSubmit((input) => {
-    // Non-admins can only create sending groups
+    // Non-admins can only create regular groups
     if (!profile?.isAdmin) {
-      input.groupType = GroupType.SendingGroup
+      input.groupType = GroupType.Regular
     }
 
     props.onSubmit(input)

--- a/frontend/src/pages/offers/PalletsEditor.tsx
+++ b/frontend/src/pages/offers/PalletsEditor.tsx
@@ -16,7 +16,7 @@ import PalletsEditorSidebar from './PalletsEditorSidebar'
 import ViewLineItem from './ViewLineItem'
 import ViewPallet from './ViewPallet'
 interface Props {
-  offerId: number
+  offer: OfferQuery['offer']
   pallets?: OfferQuery['offer']['pallets']
 }
 
@@ -24,7 +24,7 @@ interface Props {
  * This is a 2-column UI with a list of pallets on the left and details aobut
  * each line-item on the right.
  */
-const PalletsEditor: FunctionComponent<Props> = ({ offerId, pallets = [] }) => {
+const PalletsEditor: FunctionComponent<Props> = ({ offer, pallets = [] }) => {
   // TODO move this to the URL
   const [selectedPalletId, setSelectedPalletId] = useState<number>()
 
@@ -79,12 +79,12 @@ const PalletsEditor: FunctionComponent<Props> = ({ offerId, pallets = [] }) => {
         try {
           const offerData = cache.readQuery<OfferQuery>({
             query: OfferDocument,
-            variables: { id: offerId },
+            variables: { id: offer.id },
           })
 
           cache.writeQuery<OfferQuery>({
             query: OfferDocument,
-            variables: { id: offerId },
+            variables: { id: offer.id },
             data: {
               offer: Object.assign({}, offerData!.offer, {
                 pallets: [...offerData!.offer.pallets, data!.addPallet],
@@ -100,7 +100,7 @@ const PalletsEditor: FunctionComponent<Props> = ({ offerId, pallets = [] }) => {
   const onCreatePallet = (palletType: PalletType) => {
     const newPallet: PalletCreateInput = {
       palletType,
-      offerId,
+      offerId: offer.id,
     }
 
     addPallet({ variables: { input: newPallet } }).then((data) => {
@@ -159,6 +159,7 @@ const PalletsEditor: FunctionComponent<Props> = ({ offerId, pallets = [] }) => {
           <div className="h-full w-full p-8">
             {allowEditingLineItem ? (
               <LineItemForm
+                offer={offer}
                 lineItemId={selectedLineItemId}
                 palletType={
                   selectedPalletData.data?.pallet.palletType ||

--- a/frontend/src/pages/offers/ViewOfferPage.tsx
+++ b/frontend/src/pages/offers/ViewOfferPage.tsx
@@ -115,7 +115,9 @@ const ViewOfferPage: FunctionComponent = () => {
           )}
         </header>
         <main className="flex-grow flex items-stretch">
-          <PalletsEditor offerId={offerId} pallets={offer?.offer.pallets} />
+          {offer?.offer && (
+            <PalletsEditor offer={offer.offer} pallets={offer?.offer.pallets} />
+          )}
         </main>
       </div>
     </LayoutWithNav>

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -25,10 +25,8 @@ export function formatGroupType(type: GroupType) {
   switch (type) {
     case GroupType.DaHub:
       return 'DA hub'
-    case GroupType.ReceivingGroup:
-      return 'Receiving group'
-    case GroupType.SendingGroup:
-      return 'Sending group'
+    case GroupType.Regular:
+      return 'Regular group'
     default:
       throw new Error(`Unknown GroupType: ${type}`)
   }

--- a/schema.graphql
+++ b/schema.graphql
@@ -189,9 +189,8 @@ input MoneyAmountInput {
 }
 
 enum GroupType {
+  REGULAR
   DA_HUB
-  RECEIVING_GROUP
-  SENDING_GROUP
 }
 
 type UserProfile {

--- a/src/resolvers/group.ts
+++ b/src/resolvers/group.ts
@@ -107,11 +107,8 @@ const addGroup: MutationResolvers['addGroup'] = async (
     throw new UserInputError('Group arguments invalid', valid.errors)
   }
 
-  // Non-admins should only be allowed to create sending groups
-  if (
-    valid.value.groupType !== GroupType.SendingGroup &&
-    !context.auth.isAdmin
-  ) {
+  // Non-admins should only be allowed to create regular groups
+  if (valid.value.groupType !== GroupType.Regular && !context.auth.isAdmin) {
     throw new ForbiddenError(`Non-admins can only create sending groups`)
   }
 

--- a/src/resolvers/line_items.ts
+++ b/src/resolvers/line_items.ts
@@ -266,8 +266,8 @@ async function getUpdateGroupIdAttr(
     throw new UserInputError(`Group ${input[attr]} does not exist`)
   }
 
-  if (group.groupType !== GroupType.ReceivingGroup) {
-    throw new UserInputError(`Group ${input[attr]} is not a receiving group`)
+  if (group.groupType !== GroupType.Regular) {
+    throw new UserInputError(`Group ${input[attr]} is not a regular group`)
   }
 
   return input[attr]

--- a/src/resolvers/offer.ts
+++ b/src/resolvers/offer.ts
@@ -61,10 +61,12 @@ const addOffer: MutationResolvers['addOffer'] = async (
   })
 
   const sendingGroup = await sendingGroupPromise
-  if (
-    sendingGroup?.captainId !== context.auth.userId &&
-    !context.auth.isAdmin
-  ) {
+  if (sendingGroup == null) {
+    throw new UserInputError(
+      `Group ${valid.value.sendingGroupId} does not exist`,
+    )
+  }
+  if (sendingGroup.captainId !== context.auth.userId && !context.auth.isAdmin) {
     throw new ForbiddenError(
       `User ${context.auth.userId} not permitted to create offer for group ${valid.value.sendingGroupId}`,
     )

--- a/src/tests/offers_api.test.ts
+++ b/src/tests/offers_api.test.ts
@@ -57,7 +57,7 @@ describe('Offers API', () => {
 
     group2 = await createGroup({
       name: 'group 2',
-      groupType: GroupType.ReceivingGroup,
+      groupType: GroupType.Regular,
       primaryLocation: { countryCode: 'FR', townCity: 'Bordeaux' },
       primaryContact: {
         name: 'Second Contact',

--- a/src/tests/shipments_api.test.ts
+++ b/src/tests/shipments_api.test.ts
@@ -39,7 +39,7 @@ describe('Shipments API', () => {
     })
     group2 = await createGroup({
       name: 'group 2',
-      groupType: GroupType.ReceivingGroup,
+      groupType: GroupType.Regular,
       primaryLocation: { countryCode: 'FR', townCity: 'Bordeaux' },
       primaryContact: {
         name: 'Second Contact',
@@ -269,7 +269,7 @@ describe('Shipments API', () => {
       beforeEach(async () => {
         group3 = await createGroup({
           name: 'group 3',
-          groupType: GroupType.ReceivingGroup,
+          groupType: GroupType.Regular,
           primaryLocation: { countryCode: 'DE', townCity: 'Berlin' },
           primaryContact: {
             name: 'Third Contact',
@@ -278,7 +278,7 @@ describe('Shipments API', () => {
         })
         group4 = await createGroup({
           name: 'group 4',
-          groupType: GroupType.ReceivingGroup,
+          groupType: GroupType.Regular,
           primaryLocation: { countryCode: 'SE', townCity: 'Lund' },
           primaryContact: {
             name: 'Fourth Contact',
@@ -287,7 +287,7 @@ describe('Shipments API', () => {
         })
         group5 = await createGroup({
           name: 'group 5',
-          groupType: GroupType.ReceivingGroup,
+          groupType: GroupType.Regular,
           primaryLocation: { countryCode: 'NO', townCity: 'Trondheim' },
           primaryContact: {
             name: 'Fifth Contact',


### PR DESCRIPTION
The current implementation in the backend was not enforcing the sending group to actually be of that type.
In addition it would have not allowed for a group that is marked as a sending group to ever receive

Closes #298