### PR TITLE
Add admin UI for managing users

### DIFF
--- a/frontend/src/AppRoot.tsx
+++ b/frontend/src/AppRoot.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-router-dom'
 import { apolloClient } from './apolloClient'
 import { AuthProvider, useAuth } from './hooks/useAuth'
+import AdminUsers from './pages/admin/Users'
 import AdminPage from './pages/AdminPage'
 import ConfirmEmailWithTokenPage from './pages/ConfirmEmailWithTokenPage'
 import ApolloDemoPage from './pages/demo/ApolloDemo'
@@ -64,6 +65,7 @@ const App = () => {
               <Route path={ROUTES.HOME} element={<HomePage />} />
               <Route path={ROUTES.ADMIN_ROOT} element={<AdminPage />} />
               <Route path={ROUTES.GROUP_LIST} element={<GroupList />} />
+              <Route path={ROUTES.USERS} element={<AdminUsers />} />
               <Route path={ROUTES.GROUP_CREATE} element={<GroupCreatePage />} />
               <Route path={ROUTES.GROUP_EDIT} element={<GroupEditPage />} />
               <Route path={ROUTES.GROUP_VIEW} element={<GroupViewPage />} />

--- a/frontend/src/components/icons/StarIcon.tsx
+++ b/frontend/src/components/icons/StarIcon.tsx
@@ -1,0 +1,20 @@
+import { FunctionComponent, SVGProps } from 'react'
+
+const StarIcon: FunctionComponent<SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="feather feather-star"
+  >
+    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+  </svg>
+)
+
+export default StarIcon

--- a/frontend/src/hooks/useAdmin.tsx
+++ b/frontend/src/hooks/useAdmin.tsx
@@ -1,0 +1,42 @@
+import { headers, SERVER_URL, throwOnProblem } from './useAuth'
+
+export type User = {
+  id: number
+  email: string
+  name: string
+  isAdmin: boolean
+  isConfirmed: boolean
+}
+
+const listUsers = (): Promise<User[]> =>
+  fetch(`${SERVER_URL}/users`, {
+    credentials: 'include',
+  })
+    .then(throwOnProblem(`Fetching users failed!`))
+    .then((response) => response.json() as Promise<User[]>)
+
+const updateUser = ({
+  id,
+  ...update
+}: {
+  id: number
+  email?: string
+  isConfirmed?: boolean
+  isAdmin?: boolean
+  name?: boolean
+}) =>
+  fetch(`${SERVER_URL}/user/${id}`, {
+    credentials: 'include',
+    method: 'PATCH',
+    headers: {
+      ...headers,
+    },
+    body: JSON.stringify(update),
+  }).then(throwOnProblem(`Updating user failed!`))
+
+export const useAdmin = () => {
+  return {
+    listUsers,
+    updateUser,
+  }
+}

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -37,7 +37,7 @@ export class AuthError extends Error {
  * @see https://datatracker.ietf.org/doc/html/rfc7807#section-3
  * @throws AuthError
  */
-const throwOnProblem =
+export const throwOnProblem =
   (fallbackTitle: string) =>
   async (response: Response): Promise<Response> => {
     const { ok, status: httpStatusCode } = response
@@ -84,9 +84,9 @@ export const AuthContext = createContext<AuthInfo>({
 
 export const useAuth = () => useContext(AuthContext)
 
-const SERVER_URL = process.env.REACT_APP_SERVER_URL?.replace(/\/$/, '')
+export const SERVER_URL = process.env.REACT_APP_SERVER_URL?.replace(/\/$/, '')
 
-const headers = {
+export const headers = {
   'content-type': 'application/json; charset=utf-8',
 }
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,13 +1,17 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import * as ReactDOMClient from 'react-dom/client'
 import App from './AppRoot'
 import './stylesheets/index.css'
 
 console.log('endpoint', process.env.REACT_APP_SERVER_URL)
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById('root'),
-)
+const container = document.getElementById('root')
+
+if (container !== null) {
+  const root = ReactDOMClient.createRoot(container)
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  )
+}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react'
 import { Link } from 'react-router-dom'
 import CogIcon from '../components/icons/CogIcon'
+import UserIcon from '../components/icons/UserIcon'
 import LayoutWithNav from '../layouts/LayoutWithNav'
 
 /**
@@ -19,7 +20,9 @@ const AdminPage: FunctionComponent = () => {
               <CogIcon className="w-5 h-5 mr-1" />
               Manage groups
             </Link>
-            <Link to="/users">Users (in construction)</Link>
+            <Link to="/users" className="flex items-center hover:underline">
+              <UserIcon className="w-5 h-5 mr-1" /> Users
+            </Link>
           </div>
         </main>
       </div>

--- a/frontend/src/pages/ConfirmEmailWithTokenPage.tsx
+++ b/frontend/src/pages/ConfirmEmailWithTokenPage.tsx
@@ -36,9 +36,24 @@ const ConfirmEmailWithTokenPage: FunctionComponent = () => {
               </p>
             </Success>
           )}
-          <p className="mt-4 mb-6">
+          <p className="mt-4">
             In order to complete your registration, please provide the token you
             have received by email.
+          </p>
+          <p className="mt-4">
+            In case you do not receive the token, double-check that your email
+            address is spelled correctly. If not, register again with your
+            correct email address.
+          </p>
+          <p className="mt-4">Also check your SPAM folder.</p>
+          <p className="mt-4 mb-6">
+            If you still dont't have the token, ask a Shipment Tracker
+            administrator to activate your account, or if you don't know one,
+            reach out to{' '}
+            <a href="mailto:tools@distributeaid.org">
+              <code>tools@distributeaid.org</code>
+            </a>{' '}
+            so we can activate your account for you.
           </p>
           <form>
             <TextField

--- a/frontend/src/pages/admin/Users.tsx
+++ b/frontend/src/pages/admin/Users.tsx
@@ -1,0 +1,124 @@
+import { FunctionComponent, useCallback, useEffect, useState } from 'react'
+import Button from '../../components/Button'
+import StarIcon from '../../components/icons/StarIcon'
+import { useAdmin, User } from '../../hooks/useAdmin'
+import LayoutWithNav from '../../layouts/LayoutWithNav'
+
+const AdminUsers: FunctionComponent = () => {
+  const { listUsers, updateUser } = useAdmin()
+  const [users, setUsers] = useState<User[]>([])
+
+  const fetchUsers = useCallback(() => {
+    listUsers()
+      .then((users) => {
+        setUsers(users)
+      })
+      .catch(console.error)
+  }, [listUsers])
+
+  useEffect(() => {
+    fetchUsers()
+  }, [fetchUsers])
+
+  return (
+    <LayoutWithNav>
+      <div className="max-w-5xl mx-auto bg-white border-l border-r border-gray-200 min-h-content">
+        <header className="p-6 border-b border-gray-200 flex items-center justify-between">
+          <h1 className="text-navy-800 text-3xl">Users</h1>
+        </header>
+        <main className="overflow-x-auto pb-8">
+          <table>
+            <thead>
+              <tr>
+                <th></th>
+                <th>Name</th>
+                <th>Email</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {users
+                .sort(({ id: a }, { id: b }) => a - b)
+                .sort(
+                  ({ isAdmin: a }, { isAdmin: b }) => (a ? 0 : 1) - (b ? 0 : 1),
+                )
+                .map((user) => (
+                  <tr key={user.id}>
+                    <td>
+                      {user.isAdmin ? (
+                        <abbr title="Admin">
+                          <StarIcon />
+                        </abbr>
+                      ) : (
+                        ''
+                      )}
+                    </td>
+                    <td>{user.name}</td>
+                    <td>
+                      <a href={`mailto:${user.email}`}>{user.email}</a>
+                    </td>
+                    <th>
+                      {user.isConfirmed ? (
+                        <Button
+                          type="button"
+                          onClick={() => {
+                            updateUser({
+                              id: user.id,
+                              isConfirmed: false,
+                            }).then(() => fetchUsers())
+                          }}
+                          variant={'danger'}
+                        >
+                          deactivate
+                        </Button>
+                      ) : (
+                        <Button
+                          type="button"
+                          onClick={() => {
+                            updateUser({ id: user.id, isConfirmed: true }).then(
+                              () => fetchUsers(),
+                            )
+                          }}
+                          variant={'primary'}
+                        >
+                          activate
+                        </Button>
+                      )}
+                      {user.isAdmin ? (
+                        <Button
+                          type="button"
+                          onClick={() => {
+                            updateUser({
+                              id: user.id,
+                              isAdmin: false,
+                            }).then(() => fetchUsers())
+                          }}
+                          variant={'danger'}
+                        >
+                          revoke admin privileges
+                        </Button>
+                      ) : (
+                        <Button
+                          type="button"
+                          onClick={() => {
+                            updateUser({ id: user.id, isAdmin: true }).then(
+                              () => fetchUsers(),
+                            )
+                          }}
+                          variant={'danger'}
+                        >
+                          make admin
+                        </Button>
+                      )}
+                    </th>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </main>
+      </div>
+    </LayoutWithNav>
+  )
+}
+
+export default AdminUsers

--- a/frontend/src/utils/routes.ts
+++ b/frontend/src/utils/routes.ts
@@ -31,6 +31,7 @@ export const ROUTES = {
   KITCHEN_SINK: '/kitchen-sink',
   FORM_DEMO: '/form-demo',
   CONFIRM_EMAIL_WITH_TOKEN: '/register/confirm',
+  USERS: '/users',
 }
 
 export const groupViewRoute = (groupId: number): string =>

--- a/src/input-validation/trimAll.spec.ts
+++ b/src/input-validation/trimAll.spec.ts
@@ -1,4 +1,4 @@
-import { trimAll } from '../input-validation/trimAll'
+import { trimAll } from './trimAll'
 
 describe('trimAll', () => {
   it('should trim all whitespace in an object', () =>

--- a/src/routes/me.ts
+++ b/src/routes/me.ts
@@ -1,11 +1,12 @@
 import { Request, Response } from 'express'
 import { AuthContext } from '../authenticateRequest'
 import UserAccount from '../models/user_account'
+import { HTTPStatusCode } from '../rest/response/HttpStatusCode'
 
 const getProfile = async (request: Request, response: Response) => {
   const authContext = request.user as AuthContext
   const user = await UserAccount.findByPk(authContext.userId)
-  if (user === null) return response.send(404).end()
+  if (user === null) return response.sendStatus(HTTPStatusCode.NotFound).end()
   return response
     .json({
       email: user.email,

--- a/src/routes/user/update.ts
+++ b/src/routes/user/update.ts
@@ -1,0 +1,57 @@
+import { Type } from '@sinclair/typebox'
+import { Request, Response } from 'express'
+import { AuthContext } from '../../authenticateRequest'
+import { errorsToProblemDetail } from '../../input-validation/errorsToProblemDetail'
+import { validateIdInput } from '../../input-validation/idInputSchema'
+import { validateWithJSONSchema } from '../../input-validation/validateWithJSONSchema'
+import UserAccount from '../../models/user_account'
+import { HTTPStatusCode } from '../../rest/response/HttpStatusCode'
+import { respondWithProblem } from '../../rest/response/problem'
+import { emailInput } from '../register'
+
+const adminUpdateUserInput = Type.Object(
+  {
+    isConfirmed: Type.Optional(Type.Boolean()),
+    isAdmin: Type.Optional(Type.Boolean()),
+    email: Type.Optional(emailInput),
+    name: Type.Optional(Type.String({ minLength: 1, maxLength: 255 })),
+  },
+  { additionalProperties: false },
+)
+
+const validateAdminUpdateUserInput =
+  validateWithJSONSchema(adminUpdateUserInput)
+
+export const adminUpdateUser = async (request: Request, response: Response) => {
+  const id = parseInt(request.params.id, 10)
+  // Validate user id and update input
+  const validId = validateIdInput({ id })
+  if ('errors' in validId) {
+    return respondWithProblem(response, errorsToProblemDetail(validId.errors))
+  }
+
+  const validInput = validateAdminUpdateUserInput(request.body)
+  if ('errors' in validInput) {
+    return respondWithProblem(
+      response,
+      errorsToProblemDetail(validInput.errors),
+    )
+  }
+
+  // Check if user is admin
+  const authContext = request.user as AuthContext
+  if (!authContext.isAdmin)
+    return response.sendStatus(HTTPStatusCode.Forbidden).end()
+
+  // Find user
+  const user = await UserAccount.findByPk(validId.value.id)
+  if (user === null)
+    return respondWithProblem(response, {
+      title: `User with id ${validId.value.id} not found!`,
+      status: HTTPStatusCode.NotFound,
+    })
+
+  await user.update(validInput.value)
+
+  return response.status(HTTPStatusCode.NoContent).end()
+}

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express'
+import { AuthContext } from '../authenticateRequest'
+import UserAccount from '../models/user_account'
+import { HTTPStatusCode } from '../rest/response/HttpStatusCode'
+
+export const adminListUsers = async (request: Request, response: Response) => {
+  const authContext = request.user as AuthContext
+  if (!authContext.isAdmin)
+    return response.sendStatus(HTTPStatusCode.Forbidden).end()
+  return response
+    .json(
+      (await UserAccount.findAll()).map(
+        ({ id, email, name, isAdmin, isConfirmed }) => ({
+          id,
+          email,
+          name,
+          isAdmin,
+          isConfirmed,
+        }),
+      ),
+    )
+    .end()
+}

--- a/src/server/feat/backend.ts
+++ b/src/server/feat/backend.ts
@@ -16,6 +16,8 @@ import setNewPasswordUsingTokenAndEmail from '../../routes/password/new'
 import sendVerificationTokenByEmail from '../../routes/password/token'
 import registerUser from '../../routes/register'
 import confirmRegistrationByEmail from '../../routes/register/confirm'
+import { adminUpdateUser } from '../../routes/user/update'
+import { adminListUsers } from '../../routes/users'
 import sendShipmentExportCsv from '../../sendShipmentExportCsv'
 import { addRequestId } from '../addRequestId'
 import { addVersion } from '../addVersion'
@@ -85,6 +87,9 @@ export const backend = ({
   )
 
   app.get('/auth/shipment-exports/:id', cookieAuth, sendShipmentExportCsv)
+
+  app.get('/users', cookieAuth, adminListUsers)
+  app.patch('/user/:id', cookieAuth, adminUpdateUser)
 
   app.use(compression())
 

--- a/src/tests/admin.test.ts
+++ b/src/tests/admin.test.ts
@@ -1,0 +1,158 @@
+import { json } from 'body-parser'
+import cookieParser from 'cookie-parser'
+import express, { Express } from 'express'
+import { createServer, Server } from 'http'
+import passport from 'passport'
+import request, { SuperTest, Test } from 'supertest'
+import { v4 } from 'uuid'
+import {
+  authCookie as getAuthCookie,
+  authCookieName,
+  cookieAuthStrategy,
+} from '../authenticateRequest'
+import UserAccount from '../models/user_account'
+import { HTTPStatusCode } from '../rest/response/HttpStatusCode'
+import login from '../routes/login'
+import { hashPassword } from '../routes/register'
+import { adminUpdateUser } from '../routes/user/update'
+import { adminListUsers } from '../routes/users'
+import { tokenCookieRx } from './helpers/auth'
+
+jest.setTimeout(15 * 1000)
+
+const cookieAuth = passport.authenticate('cookie', { session: false })
+passport.use(cookieAuthStrategy)
+
+const password = '2DhE.sf!f9Z3u8x'
+
+describe('User admin API', () => {
+  let app: Express
+  let httpServer: Server
+  let r: SuperTest<Test>
+
+  const getExpressCookie = getAuthCookie(1800)
+
+  beforeAll(async () => {
+    app = express()
+    app.use(cookieParser(process.env.COOKIE_SECRET ?? 'cookie-secret'))
+    app.use(json())
+    app.use(passport.initialize())
+    app.post('/auth/login', login(getExpressCookie))
+    app.get('/users', cookieAuth, adminListUsers)
+    app.patch('/user/:id', cookieAuth, adminUpdateUser)
+    httpServer = createServer(app)
+    await new Promise<void>((resolve) =>
+      httpServer.listen(8888, '127.0.0.1', undefined, resolve),
+    )
+    r = request('http://127.0.0.1:8888')
+  })
+  afterAll(async () => {
+    httpServer.close()
+  })
+
+  const getCookieForUserAccount = async ({
+    email,
+    password,
+  }: {
+    email: string
+    password: string
+  }) => {
+    const res = await r
+      .post('/auth/login')
+      .send({
+        email,
+        password,
+      })
+      .expect(HTTPStatusCode.NoContent)
+      .expect('set-cookie', tokenCookieRx)
+
+    return tokenCookieRx.exec(res.header['set-cookie'])?.[1] as string
+  }
+
+  const adminEmail = `some-admin${v4()}@example.com`
+  const userEmail = `some-user${v4()}@example.com`
+
+  /** Create and log in admin */
+  beforeAll(async () => {
+    await UserAccount.create({
+      email: adminEmail,
+      isAdmin: true,
+      name: 'Some Admin',
+      passwordHash: hashPassword(password, 1),
+      isConfirmed: true,
+    })
+    await UserAccount.create({
+      email: userEmail,
+      isAdmin: false, // not an admin
+      name: 'Some User',
+      passwordHash: hashPassword(password, 1),
+    })
+  })
+
+  let userId: number
+  describe('GET /users', () => {
+    test('admins should be allowed to list all users', async () => {
+      const adminAuthCookie = await getCookieForUserAccount({
+        email: adminEmail,
+        password,
+      })
+      const res = await r
+        .get('/users')
+        .set('Cookie', [`${authCookieName}=${adminAuthCookie}`])
+        .set('Accept', 'application/json')
+        .send()
+        .expect(HTTPStatusCode.OK)
+      const usersList = res.body as UserAccount[]
+      const adminInList = usersList.find(({ email }) => email === adminEmail)
+      const userInList = usersList.find(({ email }) => email === userEmail)
+      expect(adminInList).not.toBeUndefined()
+      expect(userInList).not.toBeUndefined()
+      expect(userInList?.isConfirmed).toEqual(false)
+      expect(userInList?.id).not.toBeUndefined()
+      userId = userInList?.id as number
+    })
+  })
+  describe('PATCH /user', () => {
+    test('admin should be allowed to edit users', async () => {
+      // Initially the user is not confirmed
+      expect((await UserAccount.findByPk(userId))?.isConfirmed).toEqual(false)
+      // Confirm the user
+      const adminAuthCookie = await getCookieForUserAccount({
+        email: adminEmail,
+        password,
+      })
+      await r
+        .patch(`/user/${userId as number}`)
+        .set('Cookie', [`${authCookieName}=${adminAuthCookie}`])
+        .send({
+          isConfirmed: true,
+        })
+        .expect(HTTPStatusCode.NoContent)
+      // Now the user is confirmed
+      expect((await UserAccount.findByPk(userId))?.isConfirmed).toEqual(true)
+    })
+  })
+  describe('users should be forbidden to use the admin APIs', () => {
+    let userAuthCookie: string
+    beforeAll(async () => {
+      userAuthCookie = await getCookieForUserAccount({
+        email: userEmail,
+        password,
+      })
+    })
+    test('users should not be allowed to list all users', () =>
+      r
+        .get('/users')
+        .set('Cookie', [`${authCookieName}=${userAuthCookie}`])
+        .send()
+        .expect(HTTPStatusCode.Forbidden))
+    test('users should not be allowed to edit users', () =>
+      r
+        .patch(`/user/${userId as number}`)
+        .set('Cookie', [`${authCookieName}=${userAuthCookie}`])
+        .send({
+          isConfirmed: true,
+        })
+        .expect(HTTPStatusCode.Forbidden))
+  })
+})

--- a/src/tests/helpers/auth.ts
+++ b/src/tests/helpers/auth.ts
@@ -1,0 +1,3 @@
+import { authCookieName } from '../../authenticateRequest'
+
+export const tokenCookieRx = new RegExp(`${authCookieName}=([^;]+);`, 'i')


### PR DESCRIPTION
This adds the REST API and the frontend UI components to allow admin users to update users. This way user accounts can be manually activated from the frontend, and also granted admin permissions.

Fixes #706