### PR TITLE
Set timezone for jest

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,7 @@
   "scripts": {
     "start": "NODE_ENV=development craco start",
     "build": "craco build",
-    "test": "jest",
+    "test": "TZ=UTC jest",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
The test in `FormattedDate.spec.tsx` was failing for me with the wrong time of day - probably because I'm in Singapore?

This is the failure I got:

<img width="578" alt="Screenshot 2022-04-07 at 14 30 56" src="https://user-images.githubusercontent.com/8995723/162134895-f4c1dbba-cf08-4864-820d-4021a819b76c.png">

Setting the timezone before running jest fixes it!
